### PR TITLE
Solver

### DIFF
--- a/Solver/Classical.agda
+++ b/Solver/Classical.agda
@@ -27,3 +27,29 @@ computePropℓ : ∀ {ℓ} (F : Formula (Fin n))
   → (P : FinVec (hProp ℓ) n)
   → (fst ∘ P) ⊢ F
 computePropℓ F {witness} P = {! ? !}
+
+private module test (P Q R : Type) (pP : isProp P) (pQ : isProp Q) (pR : isProp R) where
+  open import Cubical.Data.Sigma
+    using (_×_)
+  open import Cubical.Data.Sum
+    using (_⊎_)
+  open import Cubical.Relation.Nullary.Base
+    using (¬_; ∥_∥)
+  
+  _↔_ : Type → Type → Type
+  P ↔ Q = (P → Q) × (Q → P)
+
+  infix 0 _∥⊎∥_
+  _∥⊎∥_ : Type → Type → Type
+  P ∥⊎∥ Q = ∥ P ⊎ Q ∥
+
+  open import Cubical.Data.Fin.Literals
+  test : (P × Q → R) ↔ (P → ¬ Q ∥⊎∥ R)
+  test = computeProp
+    ((p ∧ᶠ q →ᶠ r) ↔ᶠ (p →ᶠ ¬ᶠ q ∨ᶠ r))
+    ((P , pP) ∷ (Q , pQ) ∷ (R , pR) ∷ [])
+    where
+      p q r : Formula (Fin 3)
+      p = 0 ᶠ
+      q = 1 ᶠ
+      r = 2 ᶠ

--- a/Solver/Classical.agda
+++ b/Solver/Classical.agda
@@ -1,0 +1,29 @@
+open import Classical.Axioms
+open import Classical.Axioms.Resizing
+module Solver.Classical (decide : LEM) where
+open import Solver.Formula
+open Models
+
+open import Classical.Preliminary.DecidablePropositions
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function using (_∘_; const)
+open import Cubical.Data.Nat.Base
+open import Cubical.Data.Fin.Base
+open import Cubical.Data.Bool
+
+private variable
+  n : ℕ
+
+computeProp : (F : Formula (Fin n))
+  → {Bool→Type (binFoldBool (_⊨ F))}
+  → (P : FinVec (hProp ℓ-zero) n)
+  → (fst ∘ P) ⊢ F
+computeProp F {witness} P = computeDec F {witness} (hProp→DecProp decide ∘ P)
+
+computePropℓ : ∀ {ℓ} (F : Formula (Fin n))
+  → {Bool→Type (binFoldBool (_⊨ F))}
+  → (P : FinVec (hProp ℓ) n)
+  → (fst ∘ P) ⊢ F
+computePropℓ F {witness} P = {! ? !}

--- a/Solver/Classical.agda
+++ b/Solver/Classical.agda
@@ -22,11 +22,14 @@ computeProp : (F : Formula (Fin n))
   → (fst ∘ P) ⊢ F
 computeProp F {witness} P = computeDec F {witness} (hProp→DecProp decide ∘ P)
 
-computePropℓ : ∀ {ℓ} (F : Formula (Fin n))
-  → {Bool→Type (binFoldBool (_⊨ F))}
-  → (P : FinVec (hProp ℓ) n)
-  → (fst ∘ P) ⊢ F
-computePropℓ F {witness} P = {! ? !}
+-- Evil syntax
+infixr -1 _⅋_
+_⅋_ = _∷_
+infixl 0 _⟧
+_⟧ : ∀ {ℓ}{A : Type ℓ} → A → FinVec A 1
+v ⟧ = v ∷ []
+infix -2 Solve_⟦_
+Solve_⟦_ = computeProp
 
 private module test (P Q R : Type) (pP : isProp P) (pQ : isProp Q) (pR : isProp R) where
   open import Cubical.Data.Sigma
@@ -43,13 +46,7 @@ private module test (P Q R : Type) (pP : isProp P) (pQ : isProp Q) (pR : isProp 
   _∥⊎∥_ : Type → Type → Type
   P ∥⊎∥ Q = ∥ P ⊎ Q ∥
 
-  open import Cubical.Data.Fin.Literals
   test : (P × Q → R) ↔ (P → ¬ Q ∥⊎∥ R)
-  test = computeProp
-    ((p ∧ᶠ q →ᶠ r) ↔ᶠ (p →ᶠ ¬ᶠ q ∨ᶠ r))
-    ((P , pP) ∷ (Q , pQ) ∷ (R , pR) ∷ [])
-    where
-      p q r : Formula (Fin 3)
-      p = 0 ᶠ
-      q = 1 ᶠ
-      r = 2 ᶠ
+  test = Solve (0 ∧ᶠ 1 →ᶠ 2) ↔ᶠ (0 →ᶠ ¬ᶠ 1 ∨ᶠ 2)
+    ⟦ P , pP ⅋ Q , pQ ⅋ R , pR ⟧
+

--- a/Solver/Formula.agda
+++ b/Solver/Formula.agda
@@ -256,3 +256,15 @@ module NbE where
         eq ((H , pH) , yes p) = sym (isContr→≡Unit (p , pH p))
         eq ((H , pH) , no ¬p) = ua (uninhabEquiv (λ z → z) ¬p)
 open NbE public
+
+module Literals {n : ℕ} where
+  open import Agda.Builtin.FromNat
+    renaming (Number to HasFromNat)
+  open import Cubical.Data.Fin.Literals
+  instance
+    fromNatFormula : HasFromNat (Formula (Fin (suc n)))
+    fromNatFormula = record
+      { Constraint = fromNatFin {n} .HasFromNat.Constraint
+      ; fromNat    = λ m ⦃ m≤n ⦄ → fromNatFin .HasFromNat.fromNat m ᶠ
+      }
+open Literals public

--- a/Solver/Formula.agda
+++ b/Solver/Formula.agda
@@ -76,7 +76,7 @@ data Formula (a : Type) : Type where
   ¬ᶠ_ : (F : Formula a) → Formula a
   _∧ᶠ_ _∨ᶠ_ _→ᶠ_ _↔ᶠ_ : (F G : Formula a) → Formula a
 
-private module _ {a : Type} where
+module Models {a : Type} where
   infix 30 _⊢_
   _⊢_ : (a → Type ℓ) → Formula a → Type ℓ
   Γ ⊢ (ϕ ᶠ) = Γ ϕ
@@ -171,7 +171,7 @@ private module _ {a : Type} where
     ... | false | true  | fˢ | fᶜ | gˢ | gᶜ = fᶜ (snd t (gˢ tt))
     ... | true  | false | fˢ | fᶜ | gˢ | gᶜ = gᶜ (fst t (fˢ tt))
     ... | true  | true  | fˢ | fᶜ | gˢ | gᶜ = tt
-
+open Models
 -- Next, we put the automation to use.
 
 open import Cubical.Data.Nat.Base

--- a/Solver/Formula.agda
+++ b/Solver/Formula.agda
@@ -256,14 +256,3 @@ module NbE where
         eq ((H , pH) , yes p) = sym (isContr→≡Unit (p , pH p))
         eq ((H , pH) , no ¬p) = ua (uninhabEquiv (λ z → z) ¬p)
 open NbE public
-
-private module test where
-  open import Cubical.Data.Fin.Literals
-  test : (P Q : Type)
-    → (pP : isProp P) (pQ : isProp Q)
-    → (dP : Dec P) (dQ : Dec Q)
-    → ((P → Q) → P) → P
-  test P Q pP pQ dP dQ = computeDec
-    (((0 ᶠ →ᶠ 1 ᶠ) →ᶠ 0 ᶠ) →ᶠ 0 ᶠ)
-    (((P , pP), dP) ∷
-    ((Q , pQ), dQ) ∷ [])

--- a/Solver/Formula.agda
+++ b/Solver/Formula.agda
@@ -1,14 +1,16 @@
 {-# OPTIONS --safe #-}
 module Solver.Formula where
 open import Cubical.Foundations.Prelude
-open import Cubical.Foundations.HLevels
-open import Cubical.Foundations.Univalence
+open import Cubical.Foundations.HLevels using (isProp×; isPropΠ)
+open import Cubical.Foundations.Univalence using (ua)
 open import Cubical.Foundations.Function using (_∘_; const)
 open import Cubical.Data.Bool
 open import Cubical.Data.Unit
 open import Cubical.Data.Empty
+  using (⊥*; isProp⊥*; uninhabEquiv)
   renaming (rec to rec⊥)
 open import Cubical.Data.Sigma
+  using (_×_)
 open import Cubical.Data.Sum
   using (_⊎_; inl; inr)
   renaming (rec to rec⊎; map to map⊎)
@@ -16,9 +18,13 @@ open import Cubical.HITs.PropositionalTruncation
   using (∣_∣; squash; isPropPropTrunc)
   renaming (map to map∥∥)
 open import Cubical.Relation.Nullary.Base
+  using (Dec; yes; no; ¬_; ∥_∥)
 open import Cubical.Relation.Nullary.Properties
+  using (isProp¬; Dec∥∥)
 open import Cubical.Relation.Nullary.DecidablePropositions
+  using (DecProp)
 open import Classical.Preliminary.DecidablePropositions
+  using (DecProp→Bool)
 
 open import Classical.Preliminary.Bool
 
@@ -249,15 +255,15 @@ module NbE where
           → Bool→Type (DecProp→Bool H) ≡ H .fst .fst
         eq ((H , pH) , yes p) = sym (isContr→≡Unit (p , pH p))
         eq ((H , pH) , no ¬p) = ua (uninhabEquiv (λ z → z) ¬p)
-open NbE
+open NbE public
 
-test : (P Q : Type)
-  → (pP : isProp P) (pQ : isProp Q)
-  → (dP : Dec P) (dQ : Dec Q)
-  → ((P → Q) → P) → P
-test P Q pP pQ dP dQ = computeDec (((p →ᶠ q) →ᶠ p) →ᶠ p)
-  (((P , pP), dP) ∷ ((Q , pQ), dQ) ∷ [])
-  where
-    p q : Formula (Fin 2)
-    p = fzero ᶠ
-    q = fsuc fzero ᶠ
+private module test where
+  open import Cubical.Data.Fin.Literals
+  test : (P Q : Type)
+    → (pP : isProp P) (pQ : isProp Q)
+    → (dP : Dec P) (dQ : Dec Q)
+    → ((P → Q) → P) → P
+  test P Q pP pQ dP dQ = computeDec
+    (((0 ᶠ →ᶠ 1 ᶠ) →ᶠ 0 ᶠ) →ᶠ 0 ᶠ)
+    (((P , pP), dP) ∷
+    ((Q , pQ), dQ) ∷ [])


### PR DESCRIPTION
I wrote a test case. The syntax can probably be made better (avoiding those little `ᶠ`s).

Without univalence across levels, we still need to either start out with `Bool→Type*` everywhere (which requires a new set of lemmas not in standard library), or prove that `Γ ⊢ F` respects isomorphism.