### PR TITLE
Using Do-Notation Everywhere

### DIFF
--- a/Classical/Algebra/OrderedField/DedekindCut/Algebra.agda
+++ b/Classical/Algebra/OrderedField/DedekindCut/Algebra.agda
@@ -11,6 +11,7 @@ open import Cubical.Foundations.Function
 
 open import Cubical.Data.Sigma
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 open import Cubical.Relation.Nullary
 open import Cubical.Algebra.CommRing
 open import Cubical.Tactics.CommRingSolver.Reflection
@@ -70,88 +71,79 @@ module Algebra ⦃ 🤖 : Oracle ⦄
   +𝕂Comm a b = ≤𝕂-asym (upper⊆ b a) (upper⊆ a b)
     where
     upper⊆ : (a b : 𝕂){q : K} → q ∈ (a +𝕂 b) .upper → q ∈ (b +𝕂 a) .upper
-    upper⊆ a b {q = q} q∈upper = Inhab→∈ (+upper b a) (Prop.map
-      (λ (s , t , s∈upper , t∈upper , q≡s+t) → t , s , t∈upper , s∈upper , q≡s+t ∙ +Comm s t)
-      (∈→Inhab (+upper a b) q∈upper))
-
+    upper⊆ a b {q = q} q∈upper = Inhab→∈ (+upper b a) do
+      (s , t , s∈upper , t∈upper , q≡s+t) ← ∈→Inhab (+upper a b) q∈upper
+      return (t , s , t∈upper , s∈upper , q≡s+t ∙ +Comm s t)
 
   +𝕂Assoc : (a b c : 𝕂) → a +𝕂 (b +𝕂 c) ≡ (a +𝕂 b) +𝕂 c
   +𝕂Assoc a b c = ≤𝕂-asym upper⊇ upper⊆
     where
     upper⊆ : {q : K} → q ∈ (a +𝕂 (b +𝕂 c)) .upper → q ∈ ((a +𝕂 b) +𝕂 c) .upper
-    upper⊆ {q = q} q∈upper = Inhab→∈ (+upper (a +𝕂 b) c)
-      (Prop.rec squash₁
-      (λ (s , t , s∈upper , t∈upper , q≡s+t) →
-        Prop.map
-        (λ (r , w , r∈upper , w∈upper , t≡r+w) →
-          s + r , w ,
-          Inhab→∈ (+upper a b) ∣ s , r , s∈upper , r∈upper , refl ∣₁ ,
-          w∈upper , q≡s+t ∙ (λ i → s + t≡r+w i) ∙ +Assoc s r w)
-        (∈→Inhab (+upper b c) t∈upper))
-      (∈→Inhab (+upper a (b +𝕂 c)) q∈upper))
+    upper⊆ {q = q} q∈upper = Inhab→∈ (+upper (a +𝕂 b) c) do
+      (s , t , s∈upper , t∈upper , q≡s+t) ← ∈→Inhab (+upper a (b +𝕂 c)) q∈upper
+      (r , w , r∈upper , w∈upper , t≡r+w) ← ∈→Inhab (+upper b c) t∈upper
+      return (s + r , w ,
+        Inhab→∈ (+upper a b) ∣ s , r , s∈upper , r∈upper , refl ∣₁ ,
+        w∈upper , q≡s+t ∙ (λ i → s + t≡r+w i) ∙ +Assoc s r w)
 
     upper⊇ : {q : K} → q ∈ ((a +𝕂 b) +𝕂 c) .upper → q ∈ (a +𝕂 (b +𝕂 c)) .upper
-    upper⊇ {q = q} q∈upper = Inhab→∈ (+upper a (b +𝕂 c))
-      (Prop.rec squash₁
-      (λ (s , t , s∈upper , t∈upper , q≡s+t) →
-        Prop.map
-        (λ (r , w , r∈upper , w∈upper , s≡r+w) →
-          r , w + t ,
-          r∈upper , Inhab→∈ (+upper b c) ∣ w , t , w∈upper , t∈upper , refl ∣₁ ,
-          q≡s+t ∙ (λ i → s≡r+w i + t) ∙ sym (+Assoc r w t))
-        (∈→Inhab (+upper a b) s∈upper))
-      (∈→Inhab (+upper (a +𝕂 b) c) q∈upper))
+    upper⊇ {q = q} q∈upper = Inhab→∈ (+upper a (b +𝕂 c)) do
+      (s , t , s∈upper , t∈upper , q≡s+t) ← ∈→Inhab (+upper (a +𝕂 b) c) q∈upper
+      (r , w , r∈upper , w∈upper , s≡r+w) ← ∈→Inhab (+upper a b) s∈upper
+      return (r , w + t ,
+        r∈upper , Inhab→∈ (+upper b c) ∣ w , t , w∈upper , t∈upper , refl ∣₁ ,
+        q≡s+t ∙ (λ i → s≡r+w i + t) ∙ sym (+Assoc r w t))
 
 
   +𝕂IdR : (a : 𝕂) → a +𝕂 𝟘 ≡ a
   +𝕂IdR a = ≤𝕂-asym upper⊇ upper⊆
     where
     upper⊆ : {q : K} → q ∈ (a +𝕂 𝟘) .upper → q ∈ a .upper
-    upper⊆ {q = q} q∈upper = Prop.rec (isProp∈ (a .upper))
-      (λ (s , t , s∈upper , t∈upper , q≡s+t) →
-        subst (_∈ a .upper) (sym q≡s+t)
-          (a .upper-close (s + t) s s∈upper (+-rPos→> (∈→Inhab (0r <P_) t∈upper))))
-      (∈→Inhab (+upper a 𝟘) q∈upper)
+    upper⊆ {q = q} q∈upper =
+      proof _ , isProp∈ (a .upper) by do
+      (s , t , s∈upper , t∈upper , q≡s+t) ← ∈→Inhab (+upper a 𝟘) q∈upper
+      return (subst (_∈ a .upper) (sym q≡s+t)
+        (a .upper-close (s + t) s s∈upper (+-rPos→> (∈→Inhab (0r <P_) t∈upper))))
 
     upper⊇ : {q : K} → q ∈ a .upper → q ∈ (a +𝕂 𝟘) .upper
-    upper⊇ {q = q} q∈upper = Prop.rec (isProp∈ ((a +𝕂 𝟘) .upper))
-      (λ (r , r<q , r∈upper) →
+    upper⊇ {q = q} q∈upper =
+      proof _ , isProp∈ ((a +𝕂 𝟘) .upper) by do
+      (r , r<q , r∈upper) ← a .upper-round q q∈upper
+      return (
         Inhab→∈ (+upper a 𝟘) ∣ r , q - r , r∈upper ,
         Inhab→∈ (0r <P_) (>→Diff>0 r<q) , helper1 q r ∣₁)
-      (a .upper-round q q∈upper)
 
 
   +𝕂InvR : (a : 𝕂) → a +𝕂 (-𝕂 a) ≡ 𝟘
   +𝕂InvR a = ≤𝕂-asym upper⊇ upper⊆
     where
     upper⊆ : {q : K} → q ∈ (a +𝕂 (-𝕂 a)) .upper → q ∈ 𝟘 .upper
-    upper⊆ {q = q} q∈upper = Prop.rec (isProp∈ (𝟘 .upper))
-      (λ (s , t , s∈upper , t∈upper , q≡s+t) → Prop.rec (isProp∈ (𝟘 .upper))
-        (λ (p , p<r∈upper , t>-p) →
-          let p<s : p < s
-              p<s = p<r∈upper s s∈upper
-              -p>-s : - p > - s
-              -p>-s = -Reverse< p<s
-              s+t>s-s : s + t > s - s
-              s+t>s-s = <-trans (+-lPres< {z = s} -p>-s) (+-lPres< {z = s} t>-p)
-              s+t>0 : s + t > 0r
-              s+t>0 = subst (s + t >_) (+InvR s) s+t>s-s
-              q>0 : q > 0r
-              q>0 = subst (_> 0r) (sym q≡s+t) s+t>0
-          in  Inhab→∈ (0r <P_) q>0)
-        (∈→Inhab (-upper a) t∈upper))
-      (∈→Inhab (+upper a (-𝕂 a)) q∈upper)
+    upper⊆ {q = q} q∈upper =
+      proof _ , isProp∈ (𝟘 .upper) by do
+      (s , t , s∈upper , t∈upper , q≡s+t) ← ∈→Inhab (+upper a (-𝕂 a)) q∈upper
+      (p , p<r∈upper , t>-p) ← ∈→Inhab (-upper a) t∈upper
+      let p<s : p < s
+          p<s = p<r∈upper s s∈upper
+          -p>-s : - p > - s
+          -p>-s = -Reverse< p<s
+          s+t>s-s : s + t > s - s
+          s+t>s-s = <-trans (+-lPres< {z = s} -p>-s) (+-lPres< {z = s} t>-p)
+          s+t>0 : s + t > 0r
+          s+t>0 = subst (s + t >_) (+InvR s) s+t>s-s
+          q>0 : q > 0r
+          q>0 = subst (_> 0r) (sym q≡s+t) s+t>0
+      return (Inhab→∈ (0r <P_) q>0)
 
     upper⊇ : {q : K} → q ∈ 𝟘 .upper → q ∈ (a +𝕂 (-𝕂 a)) .upper
     upper⊇ {q = q} q∈upper =
-      let q>0 = ∈→Inhab (0r <P_) q∈upper in
-      Prop.rec (isProp∈ ((a +𝕂 (-𝕂 a)) .upper))
-      (λ (r , s , s<q∈upper , r<s , r+q∈upper) →
+      proof _ , isProp∈ ((a +𝕂 (-𝕂 a)) .upper) by do
+      let q>0 = ∈→Inhab (0r <P_) q∈upper
+      (r , s , s<q∈upper , r<s , r+q∈upper) ← archimedes a q q>0
+      return (
         Inhab→∈ (+upper a (-𝕂 a)) ∣ q + r , - r ,
         subst (_∈ a .upper) (+Comm r q) r+q∈upper ,
         Inhab→∈ (-upper a) ∣ s , s<q∈upper , -Reverse< r<s ∣₁ ,
         helper2 q r ∣₁)
-      (archimedes a q q>0)
 
 
   +𝕂IdL : (a : 𝕂) → 𝟘 +𝕂 a ≡ a
@@ -178,38 +170,31 @@ module Algebra ⦃ 🤖 : Oracle ⦄
   ·𝕂₊Comm a b = path-𝕂₊ _ _ (≤𝕂-asym (upper⊆ b a) (upper⊆ a b))
     where
     upper⊆ : (a b : 𝕂₊){q : K} → q ∈ (a ·𝕂₊ b) .fst .upper → q ∈ (b ·𝕂₊ a) .fst .upper
-    upper⊆ (a , a≥0) (b , b≥0) {q = q} q∈upper = Inhab→∈ (·upper b a) (Prop.map
-      (λ (s , t , s∈upper , t∈upper , q≡s·t) → t , s , t∈upper , s∈upper , q≡s·t ∙ ·Comm s t)
-      (∈→Inhab (·upper a b) q∈upper))
+    upper⊆ (a , a≥0) (b , b≥0) {q = q} q∈upper = Inhab→∈ (·upper b a) do
+      (s , t , s∈upper , t∈upper , q≡s·t) ← ∈→Inhab (·upper a b) q∈upper
+      return (t , s , t∈upper , s∈upper , q≡s·t ∙ ·Comm s t)
 
 
   ·𝕂₊Assoc : (a b c : 𝕂₊) → a ·𝕂₊ (b ·𝕂₊ c) ≡ (a ·𝕂₊ b) ·𝕂₊ c
   ·𝕂₊Assoc a b c = path-𝕂₊ _ _ (≤𝕂-asym upper⊇ upper⊆)
     where
     upper⊆ : {q : K} → q ∈ (a ·𝕂₊ (b ·𝕂₊ c)) .fst .upper → q ∈ ((a ·𝕂₊ b) ·𝕂₊ c) .fst .upper
-    upper⊆ {q = q} q∈upper = Inhab→∈ (·upper₊ (a ·𝕂₊ b) c)
-      (Prop.rec squash₁
-      (λ (s , t , s∈upper , t∈upper , q≡s·t) →
-        Prop.map
-        (λ (r , w , r∈upper , w∈upper , t≡r·w) →
-          s · r , w ,
-          Inhab→∈ (·upper₊ a b) ∣ s , r , s∈upper , r∈upper , refl ∣₁ ,
-          w∈upper , q≡s·t ∙ (λ i → s · t≡r·w i) ∙ ·Assoc s r w)
-        (∈→Inhab (·upper₊ b c) t∈upper))
-      (∈→Inhab (·upper₊ a (b ·𝕂₊ c)) q∈upper))
+    upper⊆ {q = q} q∈upper = Inhab→∈ (·upper₊ (a ·𝕂₊ b) c) do
+      (s , t , s∈upper , t∈upper , q≡s·t) ← ∈→Inhab (·upper₊ a (b ·𝕂₊ c)) q∈upper
+      (r , w , r∈upper , w∈upper , t≡r·w) ← ∈→Inhab (·upper₊ b c) t∈upper
+      return (
+        s · r , w ,
+        Inhab→∈ (·upper₊ a b) ∣ s , r , s∈upper , r∈upper , refl ∣₁ ,
+        w∈upper , q≡s·t ∙ (λ i → s · t≡r·w i) ∙ ·Assoc s r w)
 
     upper⊇ : {q : K} → q ∈ ((a ·𝕂₊ b) ·𝕂₊ c) .fst .upper → q ∈ (a ·𝕂₊ (b ·𝕂₊ c)) .fst .upper
-    upper⊇ {q = q} q∈upper = Inhab→∈ (·upper₊ a (b ·𝕂₊ c))
-      (Prop.rec squash₁
-      (λ (s , t , s∈upper , t∈upper , q≡s·t) →
-        Prop.map
-        (λ (r , w , r∈upper , w∈upper , s≡r·w) →
-          r , w · t ,
-          r∈upper , Inhab→∈ (·upper₊ b c) ∣ w , t , w∈upper , t∈upper , refl ∣₁ ,
-          q≡s·t ∙ (λ i → s≡r·w i · t) ∙ sym (·Assoc r w t))
-        (∈→Inhab (·upper₊ a b) s∈upper))
-      (∈→Inhab (·upper₊ (a ·𝕂₊ b) c) q∈upper))
-
+    upper⊇ {q = q} q∈upper = Inhab→∈ (·upper₊ a (b ·𝕂₊ c)) do
+      (s , t , s∈upper , t∈upper , q≡s·t) ← ∈→Inhab (·upper₊ (a ·𝕂₊ b) c) q∈upper
+      (r , w , r∈upper , w∈upper , s≡r·w) ← ∈→Inhab (·upper₊ a b) s∈upper
+      return (
+        r , w · t ,
+        r∈upper , Inhab→∈ (·upper₊ b c) ∣ w , t , w∈upper , t∈upper , refl ∣₁ ,
+        q≡s·t ∙ (λ i → s≡r·w i · t) ∙ sym (·Assoc r w t))
 
   private
     alg-helper : (p q : K)(p≢0 : ¬ p ≡ 0r) → q ≡ p · (q · inv p≢0)
@@ -223,37 +208,39 @@ module Algebra ⦃ 🤖 : Oracle ⦄
     upper⊆ = (a ·𝕂₊ 𝟘₊) .snd
 
     upper⊇ : {q : K} → q ∈ 𝟘 .upper → q ∈ (a ·𝕂₊ 𝟘₊) .fst .upper
-    upper⊇ {q = q} q∈upper = Prop.rec (isProp∈ ((a ·𝕂₊ 𝟘₊) .fst .upper))
-      (λ (p , p∈upper) →
-        let q>0 = ∈→Inhab (0r <P_) q∈upper
-            p>0 = q∈𝕂₊→q>0 a p p∈upper
-            p≢0 = >-arefl p>0
-            p⁻¹ = inv p≢0 in
+    upper⊇ {q = q} q∈upper =
+      proof _ , isProp∈ ((a ·𝕂₊ 𝟘₊) .fst .upper) by do
+      (p , p∈upper) ← a .fst .upper-inhab
+      let q>0 = ∈→Inhab (0r <P_) q∈upper
+          p>0 = q∈𝕂₊→q>0 a p p∈upper
+          p≢0 = >-arefl p>0
+          p⁻¹ = inv p≢0
+      return (
         Inhab→∈ (·upper₊ a 𝟘₊) ∣ p , q · p⁻¹ , p∈upper ,
         Inhab→∈ (0r <P_) (·-Pres>0 q>0 (p>0→p⁻¹>0 p>0)) , alg-helper p q p≢0 ∣₁)
-      (a .fst .upper-inhab)
 
 
   ·𝕂₊IdR : (a : 𝕂₊) → a ·𝕂₊ 𝟙₊ ≡ a
   ·𝕂₊IdR a = path-𝕂₊ _ _ (≤𝕂-asym upper⊇ upper⊆)
     where
     upper⊆ : {q : K} → q ∈ (a ·𝕂₊ 𝟙₊) .fst .upper → q ∈ a .fst .upper
-    upper⊆ {q = q} q∈upper = Prop.rec (isProp∈ (a .fst .upper))
-      (λ (s , t , s∈upper , t∈upper , q≡s·t) →
-        let s>0 = q∈𝕂₊→q>0 a s s∈upper in
-        subst (_∈ a .fst .upper) (sym q≡s·t)
-          (a .fst .upper-close (s · t) s s∈upper (·-Pos·>1→> s>0 (∈→Inhab (1r <P_) t∈upper))))
-      (∈→Inhab (·upper₊ a 𝟙₊) q∈upper)
+    upper⊆ {q = q} q∈upper =
+      proof _ , isProp∈ (a .fst .upper) by do
+      (s , t , s∈upper , t∈upper , q≡s·t) ← ∈→Inhab (·upper₊ a 𝟙₊) q∈upper
+      let s>0 = q∈𝕂₊→q>0 a s s∈upper
+      return (subst (_∈ a .fst .upper) (sym q≡s·t)
+        (a .fst .upper-close (s · t) s s∈upper (·-Pos·>1→> s>0 (∈→Inhab (1r <P_) t∈upper))))
 
     upper⊇ : {q : K} → q ∈ a .fst .upper → q ∈ (a ·𝕂₊ 𝟙₊) .fst .upper
-    upper⊇ {q = q} q∈upper = Prop.rec (isProp∈ ((a ·𝕂₊ 𝟙₊) .fst .upper))
-      (λ (r , r<q , r∈upper) →
-        let r>0 = q∈𝕂₊→q>0 a r r∈upper
-            r≢0 = >-arefl r>0
-            r⁻¹ = inv r≢0 in
+    upper⊇ {q = q} q∈upper =
+      proof _ , isProp∈ ((a ·𝕂₊ 𝟙₊) .fst .upper) by do
+      (r , r<q , r∈upper) ← a .fst .upper-round q q∈upper
+      let r>0 = q∈𝕂₊→q>0 a r r∈upper
+          r≢0 = >-arefl r>0
+          r⁻¹ = inv r≢0
+      return (
         Inhab→∈ (·upper₊ a 𝟙₊) ∣ r , q · r⁻¹ , r∈upper ,
         Inhab→∈ (1r <P_) (p>q>0→p·q⁻¹>1  r>0 r<q) , alg-helper r q r≢0 ∣₁)
-      (a .fst .upper-round q q∈upper)
 
 
   ·𝕂₊ZeroL : (a : 𝕂₊) → 𝟘₊ ·𝕂₊ a ≡ 𝟘₊
@@ -265,59 +252,51 @@ module Algebra ⦃ 🤖 : Oracle ⦄
 
   private
     upper-round2 : (a : 𝕂)(p q : K) → p ∈ a .upper → q ∈ a .upper → ∥ Σ[ r ∈ K ] (r < p) × (r < q) × (r ∈ a .upper) ∥₁
-    upper-round2 a p q p∈upper q∈upper = Prop.map2
-      (λ (r , r<p , r∈upper) (s , s<q , s∈upper) →
+    upper-round2 a p q p∈upper q∈upper = do
+      (r , r<p , r∈upper) ← a .upper-round p p∈upper
+      (s , s<q , s∈upper) ← a .upper-round q q∈upper
+      return (
         case trichotomy r s of λ
         { (lt r<s) → r , r<p , <-trans r<s s<q , r∈upper
         ; (eq r≡s) → s , subst (_< p) r≡s r<p , s<q , s∈upper
         ; (gt r>s) → s , <-trans r>s r<p , s<q , s∈upper })
-      (a .upper-round p p∈upper)
-      (a .upper-round q q∈upper)
+
 
   ·𝕂₊DistR : (a b c : 𝕂₊) → (a ·𝕂₊ b) +𝕂₊ (a ·𝕂₊ c) ≡ a ·𝕂₊ (b +𝕂₊ c)
   ·𝕂₊DistR a b c = path-𝕂₊ _ _ (≤𝕂-asym upper⊇ upper⊆)
     where
     upper⊆ : {q : K} → q ∈ ((a ·𝕂₊ b) +𝕂₊ (a ·𝕂₊ c)) .fst .upper → q ∈ (a ·𝕂₊ (b +𝕂₊ c)) .fst .upper
-    upper⊆ {q = q} q∈upper = Prop.rec (isProp∈ ((a ·𝕂₊ (b +𝕂₊ c)) .fst .upper))
-      (λ (s , t , s∈upper , t∈upper , q≡s+t) →
-        Prop.rec2 (isProp∈ ((a ·𝕂₊ (b +𝕂₊ c)) .fst .upper))
-        (λ (r , w , r∈upper , w∈upper , s≡r·w)
-           (u , v , u∈upper , v∈upper , t≡u·v) →
-          Prop.rec (isProp∈ ((a ·𝕂₊ (b +𝕂₊ c)) .fst .upper))
-          (λ (x , x<r , x<u , x∈upper) →
-            let x>0 = q∈𝕂₊→q>0 a x x∈upper
-                w>0 = q∈𝕂₊→q>0 b w w∈upper
-                v>0 = q∈𝕂₊→q>0 c v v∈upper
-                x·w+x·v<r·w+u·v : (x · w) + (x · v) < (r · w) + (u · v)
-                x·w+x·v<r·w+u·v = +-Pres< (·-rPosPres< w>0 x<r) (·-rPosPres< v>0 x<u)
-                x·[w+v]<r·w+u·v : x · (w + v) < (r · w) + (u · v)
-                x·[w+v]<r·w+u·v = subst (_< ((r · w) + (u · v))) (sym (·DistR+ x w v)) x·w+x·v<r·w+u·v
-                x·[w+v]∈upper : x · (w + v) ∈ (a ·𝕂₊ (b +𝕂₊ c)) .fst .upper
-                x·[w+v]∈upper = Inhab→∈ (·upper₊ a (b +𝕂₊ c))
-                  ∣ x , w + v , x∈upper ,
-                    Inhab→∈ (+upper₊ b c) ∣ w , v , w∈upper , v∈upper , refl ∣₁ , refl ∣₁
-                r·w+u·v≡q : (r · w) + (u · v) ≡ q
-                r·w+u·v≡q = (λ i → s≡r·w (~ i) + t≡u·v (~ i)) ∙ sym q≡s+t
-                x·[w+v]<q : x · (w + v) < q
-                x·[w+v]<q = subst (x · (w + v) <_) r·w+u·v≡q x·[w+v]<r·w+u·v
-            in  (a ·𝕂₊ (b +𝕂₊ c)) .fst .upper-close _ _ x·[w+v]∈upper x·[w+v]<q)
-            (upper-round2 (a .fst) r u r∈upper u∈upper))
-        (∈→Inhab (·upper₊ a b) s∈upper)
-        (∈→Inhab (·upper₊ a c) t∈upper))
-      (∈→Inhab (+upper₊ (a ·𝕂₊ b) (a ·𝕂₊ c)) q∈upper)
+    upper⊆ {q = q} q∈upper =
+      proof _ , isProp∈ ((a ·𝕂₊ (b +𝕂₊ c)) .fst .upper) by do
+      (s , t , s∈upper , t∈upper , q≡s+t) ← ∈→Inhab (+upper₊ (a ·𝕂₊ b) (a ·𝕂₊ c)) q∈upper
+      (r , w , r∈upper , w∈upper , s≡r·w) ← ∈→Inhab (·upper₊ a b) s∈upper
+      (u , v , u∈upper , v∈upper , t≡u·v) ← ∈→Inhab (·upper₊ a c) t∈upper
+      (x , x<r , x<u , x∈upper) ← upper-round2 (a .fst) r u r∈upper u∈upper
+      let x>0 = q∈𝕂₊→q>0 a x x∈upper
+          w>0 = q∈𝕂₊→q>0 b w w∈upper
+          v>0 = q∈𝕂₊→q>0 c v v∈upper
+          x·w+x·v<r·w+u·v : x · w + x · v < r · w + u · v
+          x·w+x·v<r·w+u·v = +-Pres< (·-rPosPres< w>0 x<r) (·-rPosPres< v>0 x<u)
+          x·[w+v]<r·w+u·v : x · (w + v) < r · w + u · v
+          x·[w+v]<r·w+u·v = subst (_< (r · w + u · v)) (sym (·DistR+ x w v)) x·w+x·v<r·w+u·v
+          x·[w+v]∈upper : x · (w + v) ∈ (a ·𝕂₊ (b +𝕂₊ c)) .fst .upper
+          x·[w+v]∈upper = Inhab→∈ (·upper₊ a (b +𝕂₊ c))
+            ∣ x , w + v , x∈upper ,
+              Inhab→∈ (+upper₊ b c) ∣ w , v , w∈upper , v∈upper , refl ∣₁ , refl ∣₁
+          r·w+u·v≡q : r · w + u · v ≡ q
+          r·w+u·v≡q = (λ i → s≡r·w (~ i) + t≡u·v (~ i)) ∙ sym q≡s+t
+          x·[w+v]<q : x · (w + v) < q
+          x·[w+v]<q = subst (x · (w + v) <_) r·w+u·v≡q x·[w+v]<r·w+u·v
+      return ((a ·𝕂₊ (b +𝕂₊ c)) .fst .upper-close _ _ x·[w+v]∈upper x·[w+v]<q)
 
     upper⊇ : {q : K} → q ∈ (a ·𝕂₊ (b +𝕂₊ c)) .fst .upper → q ∈ ((a ·𝕂₊ b) +𝕂₊ (a ·𝕂₊ c)) .fst .upper
-    upper⊇ {q = q} q∈upper = Inhab→∈ (+upper₊ (a ·𝕂₊ b) (a ·𝕂₊ c))
-      (Prop.rec squash₁
-      (λ (s , t , s∈upper , t∈upper , q≡s·t) →
-        Prop.map
-        (λ (r , w , r∈upper , w∈upper , t≡r+w) →
-          s · r , s · w ,
-          Inhab→∈ (·upper₊ a b) ∣ s , r , s∈upper , r∈upper , refl ∣₁ ,
-          Inhab→∈ (·upper₊ a c) ∣ s , w , s∈upper , w∈upper , refl ∣₁ ,
-          q≡s·t ∙ cong (s ·_) t≡r+w ∙ ·DistR+ s r w)
-        (∈→Inhab (+upper₊ b c) t∈upper))
-      (∈→Inhab (·upper₊ a (b +𝕂₊ c)) q∈upper))
+    upper⊇ {q = q} q∈upper = Inhab→∈ (+upper₊ (a ·𝕂₊ b) (a ·𝕂₊ c)) do
+      (s , t , s∈upper , t∈upper , q≡s·t) ← ∈→Inhab (·upper₊ a (b +𝕂₊ c)) q∈upper
+      (r , w , r∈upper , w∈upper , t≡r+w) ← ∈→Inhab (+upper₊ b c) t∈upper
+      return (s · r , s · w ,
+        Inhab→∈ (·upper₊ a b) ∣ s , r , s∈upper , r∈upper , refl ∣₁ ,
+        Inhab→∈ (·upper₊ a c) ∣ s , w , s∈upper , w∈upper , refl ∣₁ ,
+        q≡s·t ∙ cong (s ·_) t≡r+w ∙ ·DistR+ s r w)
 
 
   -- Multiplicative Inverse
@@ -341,29 +320,29 @@ module Algebra ⦃ 🤖 : Oracle ⦄
     ·𝕂₊InvR' = ≤𝕂-asym upper⊇ upper⊆
       where
       upper⊆ : {q : K} → q ∈ a·a⁻¹ .upper → q ∈ 𝟙 .upper
-      upper⊆ {q = q} q∈upper = Prop.rec (isProp∈ (𝟙 .upper))
-        (λ (s , t , s∈upper , t∈upper , q≡s·t) → Prop.rec (isProp∈ (𝟙 .upper))
-          (λ (p , p>0 , p<r∈upper , t>p⁻¹) →
-            let p<s : p < s
-                p<s = p<r∈upper s s∈upper
-                s>0 : s > 0r
-                s>0 = <-trans q₀>0 (q₀<r∈upper s s∈upper)
-                p⁻¹ = inv (>-arefl p>0)
-                s⁻¹ = inv (>-arefl s>0)
-                p⁻¹>s⁻¹ : p⁻¹ > s⁻¹
-                p⁻¹>s⁻¹ = inv-Reverse< s>0 p>0 p<s
-                s·t>s·s⁻¹ : s · t > s · s⁻¹
-                s·t>s·s⁻¹ = <-trans (·-lPosPres< {x = s} s>0 p⁻¹>s⁻¹) (·-lPosPres< {x = s} s>0 t>p⁻¹)
-                s·t>1 : s · t > 1r
-                s·t>1 = subst (s · t >_) (·-rInv (>-arefl s>0)) s·t>s·s⁻¹
-                q>1 : q > 1r
-                q>1 = subst (_> 1r) (sym q≡s·t) s·t>1
-            in  Inhab→∈ (1r <P_) q>1)
-          (∈→Inhab (inv-upper a) t∈upper))
-        (∈→Inhab (·upper₊ a₊ a⁻¹) q∈upper)
+      upper⊆ {q = q} q∈upper =
+        proof _ , isProp∈ (𝟙 .upper) by do
+        (s , t , s∈upper , t∈upper , q≡s·t) ← ∈→Inhab (·upper₊ a₊ a⁻¹) q∈upper
+        (p , p>0 , p<r∈upper , t>p⁻¹) ← ∈→Inhab (inv-upper a) t∈upper
+        let p<s : p < s
+            p<s = p<r∈upper s s∈upper
+            s>0 : s > 0r
+            s>0 = <-trans q₀>0 (q₀<r∈upper s s∈upper)
+            p⁻¹ = inv (>-arefl p>0)
+            s⁻¹ = inv (>-arefl s>0)
+            p⁻¹>s⁻¹ : p⁻¹ > s⁻¹
+            p⁻¹>s⁻¹ = inv-Reverse< s>0 p>0 p<s
+            s·t>s·s⁻¹ : s · t > s · s⁻¹
+            s·t>s·s⁻¹ = <-trans (·-lPosPres< {x = s} s>0 p⁻¹>s⁻¹) (·-lPosPres< {x = s} s>0 t>p⁻¹)
+            s·t>1 : s · t > 1r
+            s·t>1 = subst (s · t >_) (·-rInv (>-arefl s>0)) s·t>s·s⁻¹
+            q>1 : q > 1r
+            q>1 = subst (_> 1r) (sym q≡s·t) s·t>1
+        return (Inhab→∈ (1r <P_) q>1)
 
       upper⊇ : {q : K} → q ∈ 𝟙 .upper → q ∈ a·a⁻¹ .upper
       upper⊇ {q = q} q∈upper =
+        proof _ , isProp∈ (a·a⁻¹ .upper) by do
         let q>1 = ∈→Inhab (1r <P_) q∈upper
             q-1>0 : q - 1r > 0r
             q-1>0 = subst (q - 1r >_) (+InvR 1r) (+-rPres< {z = - 1r} q>1)
@@ -374,22 +353,20 @@ module Algebra ⦃ 🤖 : Oracle ⦄
             q'<q₀ = middle<r q₀>0
             ε = q' · (q - 1r)
             ε>0 : ε > 0r
-            ε>0 = ·-Pres>0 q'>0 q-1>0 in
-        Prop.rec (isProp∈ (a·a⁻¹ .upper))
-          (λ (r , s , s<q∈upper , q'<r , r<s , r+ε∈upper) →
-            let r+ε<r·q : r + ε < r · q
-                r+ε<r·q = ineq-helper r q q' q-1>0 q'<r
-                r·q∈upper : r · q ∈ a .upper
-                r·q∈upper = a .upper-close _ _ r+ε∈upper r+ε<r·q
-                r>0 : r > 0r
-                r>0 = <-trans q'>0 q'<r
-                r⁻¹ = inv (>-arefl r>0)
-                s>0 : s > 0r
-                s>0 = <-trans r>0 r<s
-                r⁻¹∈upper : r⁻¹ ∈ a⁻¹ .fst .upper
-                r⁻¹∈upper = Inhab→∈ (inv-upper a)
-                  ∣ s , s>0 , s<q∈upper , inv-Reverse< s>0 r>0 r<s ∣₁
-            in  Inhab→∈ (·upper₊ a₊ a⁻¹)
-                  ∣ r · q , r⁻¹ , r·q∈upper , r⁻¹∈upper ,
-                    alg-helper r q (>-arefl r>0) ∙ ·Assoc r q r⁻¹ ∣₁)
-          (archimedes' a ε ε>0 q' (q₀ , q₀<r∈upper , q'<q₀))
+            ε>0 = ·-Pres>0 q'>0 q-1>0
+        (r , s , s<q∈upper , q'<r , r<s , r+ε∈upper) ← archimedes' a ε ε>0 q' (q₀ , q₀<r∈upper , q'<q₀)
+        let r+ε<r·q : r + ε < r · q
+            r+ε<r·q = ineq-helper r q q' q-1>0 q'<r
+            r·q∈upper : r · q ∈ a .upper
+            r·q∈upper = a .upper-close _ _ r+ε∈upper r+ε<r·q
+            r>0 : r > 0r
+            r>0 = <-trans q'>0 q'<r
+            r⁻¹ = inv (>-arefl r>0)
+            s>0 : s > 0r
+            s>0 = <-trans r>0 r<s
+            r⁻¹∈upper : r⁻¹ ∈ a⁻¹ .fst .upper
+            r⁻¹∈upper = Inhab→∈ (inv-upper a)
+              ∣ s , s>0 , s<q∈upper , inv-Reverse< s>0 r>0 r<s ∣₁
+        return (Inhab→∈ (·upper₊ a₊ a⁻¹)
+          ∣ r · q , r⁻¹ , r·q∈upper , r⁻¹∈upper ,
+          alg-helper r q (>-arefl r>0) ∙ ·Assoc r q r⁻¹ ∣₁)

--- a/Classical/Algebra/OrderedField/DedekindCut/Archimedes.agda
+++ b/Classical/Algebra/OrderedField/DedekindCut/Archimedes.agda
@@ -10,6 +10,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Data.Sigma
 open import Cubical.Data.Nat using (ℕ ; zero ; suc)
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 open import Cubical.Relation.Nullary
 open import Cubical.Algebra.CommRing
 open import Cubical.Tactics.CommRingSolver.Reflection
@@ -80,13 +81,12 @@ module Archimedes ⦃ 🤖 : Oracle ⦄
         ¬P0 p0 = ¬p∈upper (subst (_∈ a .upper) ((λ i → p + 0⋆q≡0 ε i) ∙ +IdR p) p0)
 
         ∃Pn : ∥ Σ[ n ∈ ℕ ] P n ∥₁
-        ∃Pn = Prop.map
-          (λ (q , q∈upper) →
-            let (n , n·ε>q-p) = archimedesK (q - p) ε ε>0
-                p+n·ε>q : p + n ⋆ ε > q
-                p+n·ε>q = subst (p + n ⋆ ε >_) (helper1 p q) (+-lPres< {z = p} n·ε>q-p)
-            in  n , a .upper-close _ _ q∈upper p+n·ε>q)
-          (a .upper-inhab)
+        ∃Pn = do
+          (q , q∈upper) ← a .upper-inhab
+          let (n , n·ε>q-p) = archimedesK (q - p) ε ε>0
+              p+n·ε>q : p + n ⋆ ε > q
+              p+n·ε>q = subst (p + n ⋆ ε >_) (helper1 p q) (+-lPres< {z = p} n·ε>q-p)
+          return (n , a .upper-close _ _ q∈upper p+n·ε>q)
 
         interval : Σ[ n ∈ ℕ ] (¬ P n) × P (suc n)
         interval = findInterval decP ¬P0 ∃Pn
@@ -110,44 +110,38 @@ module Archimedes ⦃ 🤖 : Oracle ⦄
 
       archimedes''' :
         ∥ Σ[ r ∈ K ] Σ[ s ∈ K ] (¬ s ∈ a .upper) × (q < r) × (r < s) × (r + ε) ∈ a .upper ∥₁
-      archimedes''' =
-        let (r , ¬r∈upper , p≤r , r+ε∈upper) = archimedes'' p ¬p∈upper in
-        Prop.map
-        (λ (t , t<r+ε , t∈upper) →
-          let r-q = r - q
-              r+ε-t = (r + ε) - t
-              r-q>0 : r-q > 0r
-              r-q>0 = >→Diff>0 (<≤-trans q<p p≤r)
-              r+ε-t>0 : r+ε-t > 0r
-              r+ε-t>0 = >→Diff>0 t<r+ε
-              (u , u>0 , u<r-q , u<r+ε-t) = min2 r-q>0 r+ε-t>0
-              r+ε-u = (r + ε) - u
-              r-u = r - u
-              r-u+ε = (r - u) + ε
-              r-u<r : r-u < r
-              r-u<r = -rPos→< u>0
-              r-u>q : r-u > q
-              r-u>q = >-exchange u<r-q
-              r-u+ε>t : r-u+ε > t
-              r-u+ε>t = subst (_> t) (helper2 r u ε) (>-exchange u<r+ε-t)
-          in  r-u , r , ¬r∈upper , r-u>q , r-u<r , a .upper-close _ _ t∈upper r-u+ε>t)
-        (a .upper-round _ r+ε∈upper)
+      archimedes''' = do
+        let (r , ¬r∈upper , p≤r , r+ε∈upper) = archimedes'' p ¬p∈upper
+        (t , t<r+ε , t∈upper) ← a .upper-round _ r+ε∈upper
+        let r-q = r - q
+            r+ε-t = (r + ε) - t
+            r-q>0 : r-q > 0r
+            r-q>0 = >→Diff>0 (<≤-trans q<p p≤r)
+            r+ε-t>0 : r+ε-t > 0r
+            r+ε-t>0 = >→Diff>0 t<r+ε
+            (u , u>0 , u<r-q , u<r+ε-t) = min2 r-q>0 r+ε-t>0
+            r+ε-u = (r + ε) - u
+            r-u = r - u
+            r-u+ε = (r - u) + ε
+            r-u<r : r-u < r
+            r-u<r = -rPos→< u>0
+            r-u>q : r-u > q
+            r-u>q = >-exchange u<r-q
+            r-u+ε>t : r-u+ε > t
+            r-u+ε>t = subst (_> t) (helper2 r u ε) (>-exchange u<r+ε-t)
+        return (r-u , r , ¬r∈upper , r-u>q , r-u<r , a .upper-close _ _ t∈upper r-u+ε>t)
 
 
   archimedes' : (a : 𝕂)(ε : K)(ε>0 : ε > 0r)
     → (p : K)  → Σ[ s ∈ K ] ((q : K) → q ∈ a .upper → s < q) × (p < s)
     → ∥ Σ[ r ∈ K ] Σ[ s ∈ K ] ((q : K) → q ∈ a .upper → s < q) × (p < r) × (r < s) × (r + ε) ∈ a .upper ∥₁
-  archimedes' a ε ε>0 p (s , s<q∈upper , p<s) =
-    Prop.map
-    (λ (r , s , ¬s∈upper , q<r , r<s , r+ε∈upper) →
-        r , s , ¬∈upper→<upper a _ ¬s∈upper , q<r , r<s , r+ε∈upper)
-    (archimedes''' a ε ε>0 s (<upper→¬∈upper a _ s<q∈upper) p p<s)
+  archimedes' a ε ε>0 p (s , s<q∈upper , p<s) = do
+    (r , s , ¬s∈upper , q<r , r<s , r+ε∈upper) ← archimedes''' a ε ε>0 s (<upper→¬∈upper a _ s<q∈upper) p p<s
+    return (r , s , ¬∈upper→<upper a _ ¬s∈upper , q<r , r<s , r+ε∈upper)
 
   archimedes : (a : 𝕂)(ε : K)(ε>0 : ε > 0r)
     → ∥ Σ[ r ∈ K ] Σ[ s ∈ K ] ((q : K) → q ∈ a .upper → s < q) × (r < s) × (r + ε) ∈ a .upper ∥₁
-  archimedes a ε ε>0 = Prop.rec squash₁
-    (λ (q , q<r∈upper) → Prop.map
-      (λ (r , s , s<t∈upper , p<r , r<s , r+ε∈upper) →
-          r , s , s<t∈upper , r<s , r+ε∈upper)
-      (archimedes' a ε ε>0 (q - 1r) (q , q<r∈upper , q-1<q)))
-    (a .lower-inhab)
+  archimedes a ε ε>0 = do
+    (q , q<r∈upper) ← a .lower-inhab
+    (r , s , s<t∈upper , p<r , r<s , r+ε∈upper) ← archimedes' a ε ε>0 (q - 1r) (q , q<r∈upper , q-1<q)
+    return (r , s , s<t∈upper , r<s , r+ε∈upper)

--- a/Classical/Algebra/OrderedField/DedekindCut/Base.agda
+++ b/Classical/Algebra/OrderedField/DedekindCut/Base.agda
@@ -12,6 +12,7 @@ open import Cubical.Foundations.HLevels
 open import Cubical.Data.Sigma
 open import Cubical.Data.Empty as Empty
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 open import Cubical.Relation.Nullary
 open import Cubical.Algebra.CommRing
 open import Cubical.Tactics.CommRingSolver.Reflection
@@ -215,25 +216,26 @@ module Basics ⦃ 🤖 : Oracle ⦄
 
   -𝕂_ : 𝕂 → 𝕂
   (-𝕂 a) .upper = specify (-upper a)
-  (-𝕂 a) .upper-inhab = Prop.map
-    (λ (q , q<r∈upper) →
-      (- q) + 1r , Inhab→∈ (-upper a) ∣ q , q<r∈upper , q+1>q ∣₁ )
-    (a .lower-inhab)
-  (-𝕂 a) .upper-close r q q∈upper q<r = Prop.rec (isProp∈ ((-𝕂 a) .upper))
-    (λ (p , p<r∈upper , q>-p) →
-      Inhab→∈ (-upper a) ∣ p , p<r∈upper , <-trans q>-p q<r ∣₁)
-    (∈→Inhab (-upper a) q∈upper)
-  (-𝕂 a) .upper-round q q∈upper = Prop.map
-    (λ (p , p<r∈upper , q>-p) →
-      middle (- p) q , middle<r q>-p  , Inhab→∈ (-upper a) ∣ p , p<r∈upper , middle>l q>-p ∣₁)
-    (∈→Inhab (-upper a) q∈upper)
-  (-𝕂 a) .lower-inhab = Prop.map
-    (λ (q , q∈upper) →
-      - q , λ r r∈upper → Prop.rec isProp<
-        (λ (p , p<s∈upper , r>-p) →
-          <-trans (-Reverse< (p<s∈upper q q∈upper)) r>-p)
-        (∈→Inhab (-upper a) r∈upper))
-    (a .upper-inhab)
+  (-𝕂 a) .upper-inhab = do
+    (q , q<r∈upper) ← a .lower-inhab
+    return ((- q) + 1r , Inhab→∈ (-upper a) ∣ q , q<r∈upper , q+1>q ∣₁)
+
+  (-𝕂 a) .upper-close r q q∈upper q<r =
+    proof _ , isProp∈ ((-𝕂 a) .upper) by do
+    (p , p<r∈upper , q>-p) ← ∈→Inhab (-upper a) q∈upper
+    return
+      (Inhab→∈ (-upper a) ∣ p , p<r∈upper , <-trans q>-p q<r ∣₁)
+
+  (-𝕂 a) .upper-round q q∈upper = do
+    (p , p<r∈upper , q>-p) ← ∈→Inhab (-upper a) q∈upper
+    return
+      (middle (- p) q , middle<r q>-p  , Inhab→∈ (-upper a) ∣ p , p<r∈upper , middle>l q>-p ∣₁)
+
+  (-𝕂 a) .lower-inhab = do
+    (q , q∈upper) ← a .upper-inhab
+    return (- q , λ r r∈upper → proof _ , isProp< by do
+      (p , p<s∈upper , r>-p) ← ∈→Inhab (-upper a) r∈upper
+      return (<-trans (-Reverse< (p<s∈upper q q∈upper)) r>-p))
 
 
   -- Addition
@@ -247,33 +249,37 @@ module Basics ⦃ 🤖 : Oracle ⦄
 
   _+𝕂_ : 𝕂 → 𝕂 → 𝕂
   (a +𝕂 b) .upper = specify (+upper a b)
-  (a +𝕂 b) .upper-inhab = Prop.map2
-    (λ (p , p∈upper) (q , q∈upper) →
-      p + q , Inhab→∈ (+upper a b) ∣ p , q , p∈upper , q∈upper , refl ∣₁)
-    (a .upper-inhab) (b .upper-inhab)
-  (a +𝕂 b) .upper-close r q q∈upper q<r = Prop.rec (isProp∈ ((a +𝕂 b) .upper))
-    (λ (s , t , s∈upper , t∈upper , q≡s+t) →
-      let t+r-q∈upper : (t + (r - q)) ∈ b .upper
-          t+r-q∈upper = b .upper-close _ _ t∈upper (+-rPos→> (>→Diff>0 q<r))
-          r≡s+t+r-q : r ≡ s + (t + (r - q))
-          r≡s+t+r-q = alg-helper s t r q q≡s+t
-      in  Inhab→∈ (+upper a b) ∣ s , t + (r - q) , s∈upper , t+r-q∈upper , r≡s+t+r-q ∣₁)
-    (∈→Inhab (+upper a b) q∈upper)
-  (a +𝕂 b) .upper-round q q∈upper = Prop.rec squash₁
-    (λ (s , t , s∈upper , t∈upper , q≡s+t) → Prop.map2
-      (λ (s' , s'<s , s'∈upper) (t' , t'<t , t'∈upper) →
-        s' + t' , subst (s' + t' <_) (sym q≡s+t) (+-Pres< s'<s t'<t) ,
-        Inhab→∈ (+upper a b) ∣ s' , t' , s'∈upper , t'∈upper , refl ∣₁)
-      (a .upper-round s s∈upper) (b .upper-round t t∈upper))
-    (∈→Inhab (+upper a b) q∈upper)
-  (a +𝕂 b) .lower-inhab = Prop.map2
-    (λ (p , p<r∈upper) (q , q<r∈upper) →
-        p + q , λ r r∈upper → Prop.rec isProp<
-          (λ (s , t , s∈upper , t∈upper , r≡s+t) →
-            subst (p + q <_) (sym r≡s+t)
-            (+-Pres< (p<r∈upper s s∈upper) (q<r∈upper t t∈upper)))
-          (∈→Inhab (+upper a b) r∈upper))
-    (a .lower-inhab) (b .lower-inhab)
+
+  (a +𝕂 b) .upper-inhab = do
+    (p , p∈upper) ← a .upper-inhab
+    (q , q∈upper) ← b .upper-inhab
+    return
+     (p + q , Inhab→∈ (+upper a b) ∣ p , q , p∈upper , q∈upper , refl ∣₁)
+
+  (a +𝕂 b) .upper-close r q q∈upper q<r =
+    proof _ , isProp∈ ((a +𝕂 b) .upper) by do
+    (s , t , s∈upper , t∈upper , q≡s+t) ← ∈→Inhab (+upper a b) q∈upper
+    let t+r-q∈upper : (t + (r - q)) ∈ b .upper
+        t+r-q∈upper = b .upper-close _ _ t∈upper (+-rPos→> (>→Diff>0 q<r))
+        r≡s+t+r-q : r ≡ s + (t + (r - q))
+        r≡s+t+r-q = alg-helper s t r q q≡s+t
+    return
+      (Inhab→∈ (+upper a b) ∣ s , t + (r - q) , s∈upper , t+r-q∈upper , r≡s+t+r-q ∣₁)
+
+  (a +𝕂 b) .upper-round q q∈upper = do
+    (s , t , s∈upper , t∈upper , q≡s+t) ← ∈→Inhab (+upper a b) q∈upper
+    (s' , s'<s , s'∈upper) ← a .upper-round s s∈upper
+    (t' , t'<t , t'∈upper) ← b .upper-round t t∈upper
+    return (s' + t' , subst (s' + t' <_) (sym q≡s+t) (+-Pres< s'<s t'<t) ,
+     Inhab→∈ (+upper a b) ∣ s' , t' , s'∈upper , t'∈upper , refl ∣₁)
+
+  (a +𝕂 b) .lower-inhab = do
+    (p , p<r∈upper) ← a .lower-inhab
+    (q , q<r∈upper) ← b .lower-inhab
+    return (p + q , λ r r∈upper → proof _ , isProp< by do
+      (s , t , s∈upper , t∈upper , r≡s+t) ← ∈→Inhab (+upper a b) r∈upper
+      return (subst (p + q <_) (sym r≡s+t)
+        (+-Pres< (p<r∈upper s s∈upper) (q<r∈upper t t∈upper))))
 
 
   {-
@@ -310,12 +316,12 @@ module Basics ⦃ 🤖 : Oracle ⦄
   _+𝕂₊_ : (a b : 𝕂₊) → 𝕂₊
   ((a , a≥0) +𝕂₊ (b , b≥0)) .fst = a +𝕂 b
   ((a , a≥0) +𝕂₊ (b , b≥0)) .snd q∈upper =
-    Prop.rec (isProp∈ (𝟘 .upper))
-    (λ (s , t , s∈upper , t∈upper , q≡s+t) →
-      let s>0 = ∈→Inhab (0r <P_) (a≥0 s∈upper)
-          t>0 = ∈→Inhab (0r <P_) (b≥0 t∈upper)
-      in  Inhab→∈ (0r <P_) (subst (_> 0r) (sym q≡s+t) (+-Pres>0 s>0 t>0)))
-    (∈→Inhab (+upper a b) q∈upper)
+    proof _ , isProp∈ (𝟘 .upper) by do
+    (s , t , s∈upper , t∈upper , q≡s+t) ← ∈→Inhab (+upper a b) q∈upper
+    let s>0 = ∈→Inhab (0r <P_) (a≥0 s∈upper)
+        t>0 = ∈→Inhab (0r <P_) (b≥0 t∈upper)
+    return
+      (Inhab→∈ (0r <P_) (subst (_> 0r) (sym q≡s+t) (+-Pres>0 s>0 t>0)))
 
 
   -- Multiplication
@@ -331,11 +337,12 @@ module Basics ⦃ 🤖 : Oracle ⦄
   ≥𝕂0+q∈upper→q>0 a {q = q} a≥0 q∈upper = ∈→Inhab (0r <P_) (a≥0 q∈upper)
 
   q∈·upper→q>0 : (a b : 𝕂) → a ≥𝕂 𝟘 → b ≥𝕂 𝟘 → (q : K) → q ∈ specify (·upper a b) → q > 0r
-  q∈·upper→q>0 a b a≥0 b≥0 q q∈upper = Prop.rec isProp<
-    (λ (s , t , s∈upper , t∈upper , q≡s·t) →
-      subst (_> 0r) (sym q≡s·t)
-        (·-Pres>0 (≥𝕂0+q∈upper→q>0 a a≥0 s∈upper) (≥𝕂0+q∈upper→q>0 b b≥0 t∈upper)))
-    (∈→Inhab (·upper a b) q∈upper)
+  q∈·upper→q>0 a b a≥0 b≥0 q q∈upper =
+    proof _ , isProp< by do
+    (s , t , s∈upper , t∈upper , q≡s·t) ← ∈→Inhab (·upper a b) q∈upper
+    return (subst (_> 0r) (sym q≡s·t)
+      (·-Pres>0 (≥𝕂0+q∈upper→q>0 a a≥0 s∈upper) (≥𝕂0+q∈upper→q>0 b b≥0 t∈upper)))
+
 
   private
     alg-helper' : (a b c d : K)(d≢0 : ¬ d ≡ 0r) → d ≡ a · b → c ≡ a · (b · (c · inv d≢0))
@@ -345,42 +352,47 @@ module Basics ⦃ 🤖 : Oracle ⦄
 
   _·𝕂₊_ : (a b : 𝕂₊) → 𝕂₊
   ((a , a≥0) ·𝕂₊ (b , b≥0)) .fst .upper = specify (·upper a b)
-  ((a , a≥0) ·𝕂₊ (b , b≥0)) .fst .upper-inhab = Prop.map2
-    (λ (p , p∈upper) (q , q∈upper) →
-      p · q , Inhab→∈ (·upper a b) ∣ p , q , p∈upper , q∈upper , refl ∣₁)
-    (a .upper-inhab) (b .upper-inhab)
+  ((a , a≥0) ·𝕂₊ (b , b≥0)) .fst .upper-inhab = do
+    (p , p∈upper) ← a .upper-inhab
+    (q , q∈upper) ← b .upper-inhab
+    return
+      (p · q , Inhab→∈ (·upper a b) ∣ p , q , p∈upper , q∈upper , refl ∣₁)
+
   ((a , a≥0) ·𝕂₊ (b , b≥0)) .fst .upper-close r q q∈upper q<r =
-    Prop.rec (isProp∈ (((a , a≥0) ·𝕂₊ (b , b≥0)) .fst .upper))
-    (λ (s , t , s∈upper , t∈upper , q≡s·t) →
-      let q>0 : q > 0r
-          q>0 = q∈·upper→q>0 a b a≥0 b≥0 q q∈upper
-          q≢0 : ¬ q ≡ 0r
-          q≢0 = >-arefl q>0
-          q⁻¹ = inv q≢0
-          t·r·q⁻¹∈upper : (t · (r · q⁻¹)) ∈ b .upper
-          t·r·q⁻¹∈upper = b .upper-close _ _ t∈upper
-            (·-Pos·>1→> (≥𝕂0+q∈upper→q>0 b b≥0 t∈upper) (p>q>0→p·q⁻¹>1 q>0 q<r))
-          r≡s·t·r·q⁻¹ : r ≡ s · (t · (r · q⁻¹))
-          r≡s·t·r·q⁻¹ = alg-helper' s t r q q≢0 q≡s·t
-      in  Inhab→∈ (·upper a b) ∣ s , t · (r · q⁻¹) , s∈upper , t·r·q⁻¹∈upper , r≡s·t·r·q⁻¹ ∣₁)
-    (∈→Inhab (·upper a b) q∈upper)
-  ((a , a≥0) ·𝕂₊ (b , b≥0)) .fst .upper-round q q∈upper = Prop.rec squash₁
-    (λ (s , t , s∈upper , t∈upper , q≡s·t) → Prop.map2
-      (λ (s' , s'<s , s'∈upper) (t' , t'<t , t'∈upper) →
-        s' · t' , subst (s' · t' <_) (sym q≡s·t)
-          (·-PosPres> (≥𝕂0+q∈upper→q>0 a a≥0 s'∈upper) (≥𝕂0+q∈upper→q>0 b b≥0 t'∈upper) s'<s t'<t) ,
-        Inhab→∈ (·upper a b) ∣ s' , t' , s'∈upper , t'∈upper , refl ∣₁ )
-      (a .upper-round s s∈upper) (b .upper-round t t∈upper))
-    (∈→Inhab (·upper a b) q∈upper)
+    proof _ , isProp∈ (((a , a≥0) ·𝕂₊ (b , b≥0)) .fst .upper) by do
+    (s , t , s∈upper , t∈upper , q≡s·t) ← ∈→Inhab (·upper a b) q∈upper
+    let q>0 : q > 0r
+        q>0 = q∈·upper→q>0 a b a≥0 b≥0 q q∈upper
+        q≢0 : ¬ q ≡ 0r
+        q≢0 = >-arefl q>0
+        q⁻¹ = inv q≢0
+        t·r·q⁻¹∈upper : (t · (r · q⁻¹)) ∈ b .upper
+        t·r·q⁻¹∈upper = b .upper-close _ _ t∈upper
+          (·-Pos·>1→> (≥𝕂0+q∈upper→q>0 b b≥0 t∈upper) (p>q>0→p·q⁻¹>1 q>0 q<r))
+        r≡s·t·r·q⁻¹ : r ≡ s · (t · (r · q⁻¹))
+        r≡s·t·r·q⁻¹ = alg-helper' s t r q q≢0 q≡s·t
+    return
+      (Inhab→∈ (·upper a b) ∣ s , t · (r · q⁻¹) , s∈upper , t·r·q⁻¹∈upper , r≡s·t·r·q⁻¹ ∣₁)
+
+  ((a , a≥0) ·𝕂₊ (b , b≥0)) .fst .upper-round q q∈upper = do
+    (s , t , s∈upper , t∈upper , q≡s·t) ← ∈→Inhab (·upper a b) q∈upper
+    (s' , s'<s , s'∈upper) ← a .upper-round s s∈upper
+    (t' , t'<t , t'∈upper) ← b .upper-round t t∈upper
+    return
+      (s' · t' , subst (s' · t' <_) (sym q≡s·t)
+        (·-PosPres> (≥𝕂0+q∈upper→q>0 a a≥0 s'∈upper) (≥𝕂0+q∈upper→q>0 b b≥0 t'∈upper) s'<s t'<t) ,
+       Inhab→∈ (·upper a b) ∣ s' , t' , s'∈upper , t'∈upper , refl ∣₁)
+
   ((a , a≥0) ·𝕂₊ (b , b≥0)) .fst .lower-inhab =
     ∣ - 1r , (λ r r∈upper → <-trans -1<0 (q∈·upper→q>0 a b a≥0 b≥0 r r∈upper)) ∣₁
+
   ((a , a≥0) ·𝕂₊ (b , b≥0)) .snd q∈upper =
-    Prop.rec (isProp∈ (𝟘 .upper))
-    (λ (s , t , s∈upper , t∈upper , q≡s·t) →
-      let s>0 = ∈→Inhab (0r <P_) (a≥0 s∈upper)
-          t>0 = ∈→Inhab (0r <P_) (b≥0 t∈upper)
-      in  Inhab→∈ (0r <P_) (subst (_> 0r) (sym q≡s·t) (·-Pres>0 s>0 t>0)))
-    (∈→Inhab (·upper a b) q∈upper)
+    proof _ , isProp∈ (𝟘 .upper) by do
+    (s , t , s∈upper , t∈upper , q≡s·t) ← ∈→Inhab (·upper a b) q∈upper
+    let s>0 = ∈→Inhab (0r <P_) (a≥0 s∈upper)
+        t>0 = ∈→Inhab (0r <P_) (b≥0 t∈upper)
+    return
+      (Inhab→∈ (0r <P_) (subst (_> 0r) (sym q≡s·t) (·-Pres>0 s>0 t>0)))
 
 
   -- Multiplicative Inverse
@@ -393,27 +405,29 @@ module Basics ⦃ 🤖 : Oracle ⦄
   inv𝕂₊ a q₀ q₀>0 q₀<r∈upper .fst .upper-inhab =
     let q₀⁻¹ = inv (>-arefl q₀>0) in
     ∣ q₀⁻¹ + 1r , Inhab→∈ (inv-upper a) ∣ q₀ , q₀>0 , q₀<r∈upper , q+1>q {q = q₀⁻¹} ∣₁ ∣₁
+
   inv𝕂₊ a q₀ q₀>0 q₀<r∈upper .fst .upper-close r q q∈upper q<r =
-    Prop.rec (isProp∈ (inv𝕂₊ a q₀ q₀>0 q₀<r∈upper .fst .upper))
-    (λ (p , p>0 , p<r∈upper , q>p⁻¹) →
-      Inhab→∈ (inv-upper a) ∣ p , p>0 , p<r∈upper , <-trans q>p⁻¹ q<r ∣₁)
-    (∈→Inhab (inv-upper a) q∈upper)
-  inv𝕂₊ a _ _ _ .fst .upper-round q q∈upper = Prop.map
-    (λ (p , p>0 , p<r∈upper , q>p⁻¹) →
-      let p⁻¹ = inv (>-arefl p>0) in
-      middle p⁻¹ q , middle<r q>p⁻¹  , Inhab→∈ (inv-upper a) ∣ p , p>0 , p<r∈upper , middle>l q>p⁻¹ ∣₁)
-    (∈→Inhab (inv-upper a) q∈upper)
-  inv𝕂₊ a q₀ q₀>0 q₀<r∈upper .fst .lower-inhab = Prop.map
-    (λ (q , q∈upper) →
-      let q>0 = <-trans q₀>0 (q₀<r∈upper q q∈upper)
-          q⁻¹ = inv (>-arefl q>0) in
-      q⁻¹ , λ r r∈upper → Prop.rec isProp<
-        (λ (p , p>0 , p<s∈upper , r>p⁻¹) →
-          <-trans (inv-Reverse< _ _ (p<s∈upper q q∈upper)) r>p⁻¹)
-        (∈→Inhab (inv-upper a) r∈upper))
-    (a .upper-inhab)
+    proof _ , isProp∈ (inv𝕂₊ a q₀ q₀>0 q₀<r∈upper .fst .upper) by do
+    (p , p>0 , p<r∈upper , q>p⁻¹) ← ∈→Inhab (inv-upper a) q∈upper
+    return
+      (Inhab→∈ (inv-upper a) ∣ p , p>0 , p<r∈upper , <-trans q>p⁻¹ q<r ∣₁)
+
+  inv𝕂₊ a _ _ _ .fst .upper-round q q∈upper = do
+    (p , p>0 , p<r∈upper , q>p⁻¹) ← ∈→Inhab (inv-upper a) q∈upper
+    let p⁻¹ = inv (>-arefl p>0)
+    return
+      (middle p⁻¹ q , middle<r q>p⁻¹  , Inhab→∈ (inv-upper a) ∣ p , p>0 , p<r∈upper , middle>l q>p⁻¹ ∣₁)
+
+  inv𝕂₊ a q₀ q₀>0 q₀<r∈upper .fst .lower-inhab = do
+    (q , q∈upper) ← a .upper-inhab
+    let q>0 = <-trans q₀>0 (q₀<r∈upper q q∈upper)
+        q⁻¹ = inv (>-arefl q>0)
+    return (q⁻¹ , λ r r∈upper → proof _ , isProp< by do
+      (p , p>0 , p<s∈upper , r>p⁻¹) ← ∈→Inhab (inv-upper a) r∈upper
+      return (<-trans (inv-Reverse< _ _ (p<s∈upper q q∈upper)) r>p⁻¹))
+
   inv𝕂₊ a _ _ _ .snd q∈upper =
-    Prop.rec (isProp∈ (𝟘 .upper))
-    (λ (p , p>0 , p<r∈upper , q>p⁻¹) →
-      Inhab→∈ (0r <P_) (<-trans (p>0→p⁻¹>0 p>0) q>p⁻¹))
-    (∈→Inhab (inv-upper a) q∈upper)
+    proof _ , isProp∈ (𝟘 .upper) by do
+    (p , p>0 , p<r∈upper , q>p⁻¹) ← ∈→Inhab (inv-upper a) q∈upper
+    return
+      (Inhab→∈ (0r <P_) (<-trans (p>0→p⁻¹>0 p>0) q>p⁻¹))

--- a/Classical/Algebra/OrderedField/DedekindCut/Completeness.agda
+++ b/Classical/Algebra/OrderedField/DedekindCut/Completeness.agda
@@ -10,6 +10,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
 open import Cubical.Data.Sigma
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 
 open import Classical.Axioms
 open import Classical.Foundations.Powerset
@@ -58,33 +59,35 @@ module CompletenessOfCuts ⦃ 🤖 : Oracle ⦄
     sup𝕂 : 𝕂
     sup𝕂 .upper = specify sup-upper
     sup𝕂 .upper-inhab = ∣ s + 1r , Inhab→∈ sup-upper ∣ s , bound , q+1>q ∣₁ ∣₁
-    sup𝕂 .upper-close r q q∈sup q<r = Prop.rec (isProp∈ (sup𝕂 .upper))
-      (λ (p , p∈x∈A , p<q) →
-        Inhab→∈ sup-upper ∣ p , p∈x∈A , <-trans p<q q<r ∣₁)
-      (∈→Inhab sup-upper q∈sup)
-    sup𝕂 .upper-round q q∈sup = Prop.map
-      (λ (p , p∈x∈A , p<q) →
+    sup𝕂 .upper-close r q q∈sup q<r =
+      proof _ , isProp∈ (sup𝕂 .upper) by do
+      (p , p∈x∈A , p<q) ← ∈→Inhab sup-upper q∈sup
+      return (Inhab→∈ sup-upper ∣ p , p∈x∈A , <-trans p<q q<r ∣₁)
+
+    sup𝕂 .upper-round q q∈sup = do
+      (p , p∈x∈A , p<q) ← ∈→Inhab sup-upper q∈sup
+      return (
         middle p q , middle<r p<q ,
         Inhab→∈ sup-upper ∣ p , p∈x∈A , middle>l p<q ∣₁)
-      (∈→Inhab sup-upper q∈sup)
-    sup𝕂 .lower-inhab = Prop.map
-      (λ (p , p<r∈upper) → p ,
-        λ q q∈sup → Prop.rec isProp<
-        (λ (r , r∈x∈A , r<q) →
-          <-trans (p<r∈upper r (r∈x∈A a₀ a₀∈A)) r<q)
-        (∈→Inhab sup-upper q∈sup))
-      (a₀ .lower-inhab)
+
+    sup𝕂 .lower-inhab = do
+      (p , p<r∈upper) ← a₀ .lower-inhab
+      return (p , λ q q∈sup →
+        proof _ , isProp< by do
+        (r , r∈x∈A , r<q) ← ∈→Inhab sup-upper q∈sup
+        return (<-trans (p<r∈upper r (r∈x∈A a₀ a₀∈A)) r<q))
 
     boundSup𝕂 : (x : 𝕂) → x ∈ A → x ≤𝕂 sup𝕂
-    boundSup𝕂 x x∈A {x = q} q∈sup = Prop.rec (isProp∈ (x .upper))
-      (λ (p , p∈x∈A , p<q) → x .upper-close q p (p∈x∈A x x∈A) p<q)
-      (∈→Inhab sup-upper q∈sup)
+    boundSup𝕂 x x∈A {x = q} q∈sup =
+      proof _ , isProp∈ (x .upper) by do
+      (p , p∈x∈A , p<q) ← ∈→Inhab sup-upper q∈sup
+      return (x .upper-close q p (p∈x∈A x x∈A) p<q)
 
     leastSup𝕂 : (y : 𝕂) → ((x : 𝕂) → x ∈ A → x ≤𝕂 y) → y ≥𝕂 sup𝕂
-    leastSup𝕂 y x∈A→x≤y {x = q} q∈y = Prop.rec (isProp∈ (sup𝕂 .upper))
-      (λ (r , r<q , r∈y) →
-        Inhab→∈ sup-upper ∣ r , (λ x x∈A → x∈A→x≤y x x∈A r∈y) , r<q ∣₁)
-      (y .upper-round q q∈y)
+    leastSup𝕂 y x∈A→x≤y {x = q} q∈y =
+      proof _ , isProp∈ (sup𝕂 .upper) by do
+      (r , r<q , r∈y) ← y .upper-round q q∈y
+      return (Inhab→∈ sup-upper ∣ r , (λ x x∈A → x∈A→x≤y x x∈A r∈y) , r<q ∣₁)
 
     boundSup𝕂' : (x : 𝕂) → x ∈ A → x ≤𝕂' sup𝕂
     boundSup𝕂' x h = ≤𝕂→≤𝕂' _ _ (boundSup𝕂 x h)
@@ -97,9 +100,9 @@ module CompletenessOfCuts ⦃ 🤖 : Oracle ⦄
     findBound : (A : ℙ 𝕂)
       → (b : 𝕂)(bound : (x : 𝕂) → x ∈ A → x ≤𝕂' b)
       → ∥ Σ[ s ∈ K ] ((x : 𝕂) → x ∈ A → s ∈ x .upper) ∥₁
-    findBound A b bound = Prop.map
-      (λ (s , s∈b) → s , λ x x∈A → ≤𝕂'→≤𝕂 _ _ (bound x x∈A) s∈b)
-      (b .upper-inhab)
+    findBound A b bound = do
+      (s , s∈b) ← b .upper-inhab
+      return (s , λ x x∈A → ≤𝕂'→≤𝕂 _ _ (bound x x∈A) s∈b)
 
 
   {-
@@ -109,15 +112,15 @@ module CompletenessOfCuts ⦃ 🤖 : Oracle ⦄
   -}
 
   isComplete𝕂 : isComplete 𝕂OrderedField
-  isComplete𝕂 {A = A} = Prop.rec2 (isPropSupremum A)
+  isComplete𝕂 {A = A} =
+    Prop.rec2 (isPropSupremum A)
     (λ (a₀ , a₀∈A) (b , bound) →
-      Prop.rec (isPropSupremum A)
-      (λ (s , s∈x∈A) →
-        record
+      proof _ , isPropSupremum A by do
+      (s , s∈x∈A) ← findBound A b bound
+      return record
         { sup = sup𝕂 A a₀ a₀∈A s s∈x∈A
         ; bound = boundSup𝕂' A a₀ a₀∈A s s∈x∈A
         ; least = leastSup𝕂' A a₀ a₀∈A s s∈x∈A })
-      (findBound A b bound))
 
   𝕂CompleteOrderedField : CompleteOrderedField (ℓ-max ℓ ℓ') (ℓ-max ℓ ℓ')
   𝕂CompleteOrderedField = 𝕂OrderedField , isComplete𝕂

--- a/Classical/Algebra/OrderedField/DedekindCut/UniversalProperty.agda
+++ b/Classical/Algebra/OrderedField/DedekindCut/UniversalProperty.agda
@@ -14,6 +14,7 @@ open import Cubical.Data.Empty as Empty
 open import Cubical.Data.Sum
 open import Cubical.Data.Sigma
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 open import Cubical.Relation.Nullary
 open import Cubical.Algebra.Ring
 open import Cubical.Algebra.CommRing
@@ -124,15 +125,14 @@ module UniversalProperty ⦃ 🤖 : Oracle ⦄
 
       private
         map-sub-inhab : isInhabited map-sub
-        map-sub-inhab = Prop.map
-          (λ (q , q<r∈upper) →
-            f-map q , Inhab→∈ map-prop (λ p p∈upper → homPres< _ _ (q<r∈upper _ p∈upper)))
-          (a .lower-inhab)
+        map-sub-inhab = do
+          (q , q<r∈upper) ← a .lower-inhab
+          return (f-map q , Inhab→∈ map-prop (λ p p∈upper → homPres< _ _ (q<r∈upper _ p∈upper)))
 
         map-sub-bound : isUpperBounded map-sub
-        map-sub-bound = Prop.map
-          (λ (q , q∈upper) → f-map q , (λ r r∈map → inl (∈→Inhab map-prop r∈map _ q∈upper)))
-          (a .upper-inhab)
+        map-sub-bound = do
+          (q , q∈upper) ← a .upper-inhab
+          return (f-map q , (λ r r∈map → inl (∈→Inhab map-prop r∈map _ q∈upper)))
 
       map-sup : Supremum map-sub
       map-sup = getSup map-sub-inhab map-sub-bound
@@ -142,15 +142,10 @@ module UniversalProperty ⦃ 🤖 : Oracle ⦄
 
 
       >sup-helper : (x : K') → ¬ x ∈ map-sub → ∥ Σ[ q ∈ K ] q ∈ a .upper × (f-map q <' x) ∥₁
-      >sup-helper x ¬∈sub =
-        Prop.rec squash₁
-          (λ (q , q∈a , ¬sup<fq) →
-            Prop.map
-            (λ (r , r<q , r∈upper) →
-                r , r∈upper , <≤-trans' (homPres< r q r<q) (¬<→≥' ¬sup<fq))
-            (a .upper-round q q∈a))
-          (¬∀→∃¬2 (λ _ _ → isProp<')
-            (¬map (Inhab→∈ map-prop) ¬∈sub))
+      >sup-helper x ¬∈sub = do
+        (q , q∈a , ¬sup<fq) ← ¬∀→∃¬2 (λ _ _ → isProp<') (¬map (Inhab→∈ map-prop) ¬∈sub)
+        (r , r<q , r∈upper) ← a .upper-round q q∈a
+        return (r , r∈upper , <≤-trans' (homPres< r q r<q) (¬<→≥' ¬sup<fq))
 
       >map-helper : (x : K') → x >' map-helper → ∥ Σ[ q ∈ K ] q ∈ a .upper × (f-map q <' x) ∥₁
       >map-helper x x>sup = >sup-helper x (>sup→¬∈ x map-sup x>sup)
@@ -158,13 +153,11 @@ module UniversalProperty ⦃ 🤖 : Oracle ⦄
 
       private
         ∈-helper :  ¬ map-helper ∈ map-sub → ⊥
-        ∈-helper ¬∈sub = Prop.rec isProp⊥
-          (λ (q , q∈a , sup>fq) →
-            (Prop.rec isProp⊥
-              (λ (x , fq<x , x∈sub) →
-                <'-asym fq<x (∈→Inhab map-prop x∈sub q q∈a))
-            (<sup→∃∈ _ map-sup sup>fq)))
-          (>sup-helper _ ¬∈sub)
+        ∈-helper ¬∈sub =
+          proof _ , isProp⊥ by do
+          (q , q∈a , sup>fq) ← >sup-helper _ ¬∈sub
+          (x , fq<x , x∈sub) ← <sup→∃∈ _ map-sup sup>fq
+          return (<'-asym fq<x (∈→Inhab map-prop x∈sub q q∈a))
 
       map∈sub : map-helper ∈ map-sub
       map∈sub with decide (isProp∈ map-sub)
@@ -180,10 +173,10 @@ module UniversalProperty ⦃ 🤖 : Oracle ⦄
       comp-helper : (x : K') → x ∈ map-sub (K→𝕂 q) → x ≤' f-map q
       comp-helper x x∈sub with <≤-total' (f-map q) x
       ... | inr x≤fq = x≤fq
-      ... | inl x>fq = Empty.rec (Prop.rec isProp⊥
-        (λ (r , fq<fr , fr<x) →
-          <'-asym fr<x (∈→Inhab (map-prop (K→𝕂 q)) x∈sub r (Inhab→∈ (q <P_) (homRefl< _ _ fq<fr))))
-        (findBetween x>fq))
+      ... | inl x>fq = Empty.rec (
+        proof _ , isProp⊥ by do
+        (r , fq<fr , fr<x) ← findBetween x>fq
+        return (<'-asym fr<x (∈→Inhab (map-prop (K→𝕂 q)) x∈sub r (Inhab→∈ (q <P_) (homRefl< _ _ fq<fr)))))
 
       comp-helper' : (x : K') → x ≤' f-map q → x ∈ map-sub (K→𝕂 q)
       comp-helper' x x≤fq =
@@ -229,45 +222,45 @@ module UniversalProperty ⦃ 🤖 : Oracle ⦄
       map-helper-pres> : a >𝕂 b → map-helper a >' map-helper b
       map-helper-pres> a>b with <≤-total' (map-helper b) (map-helper a)
       ... | inl fb<fa = fb<fa
-      ... | inr fa≤fb = Empty.rec
-        (Prop.rec isProp⊥
-        (λ (q , q<r∈a , q∈b) →
-          let fq∈suba : f-map q ∈ map-sub a
-              fq∈suba = Inhab→∈ (map-prop a) (λ r r∈a → homPres< _ _ (q<r∈a r r∈a))
-              fa≥fq : map-helper a ≥' f-map q
-              fa≥fq = map-sup a .bound _ fq∈suba
-              fq>fb : f-map q >' map-helper b
-              fq>fb = map-helper< b _ q∈b
-              fb<fa : map-helper b <' map-helper a
-              fb<fa = <≤-trans' fq>fb fa≥fq
-          in  <≤-asym' fb<fa fa≤fb) a>b)
+      ... | inr fa≤fb = Empty.rec (
+        proof _ , isProp⊥ by do
+        (q , q<r∈a , q∈b)  ← a>b
+        let fq∈suba : f-map q ∈ map-sub a
+            fq∈suba = Inhab→∈ (map-prop a) (λ r r∈a → homPres< _ _ (q<r∈a r r∈a))
+            fa≥fq : map-helper a ≥' f-map q
+            fa≥fq = map-sup a .bound _ fq∈suba
+            fq>fb : f-map q >' map-helper b
+            fq>fb = map-helper< b _ q∈b
+            fb<fa : map-helper b <' map-helper a
+            fb<fa = <≤-trans' fq>fb fa≥fq
+        return (<≤-asym' fb<fa fa≤fb))
 
 
     module _ (a b : 𝕂) where
 
       fa+fb≤ : (q : K) → q ∈ (a +𝕂 b) .upper → map-helper a +' map-helper b <' f-map q
-      fa+fb≤ q q∈a+b = Prop.rec isProp<'
-        (λ (s , t , s∈a , t∈b , q≡s+t) →
-          subst (map-helper a +' map-helper b <'_)
-            (sym (pres+ s t) ∙ (λ i → f-map (q≡s+t (~ i))))
-            (+-Pres<' (map-helper< a s s∈a) (map-helper< b t t∈b)))
-        (∈→Inhab (+upper a b) q∈a+b)
+      fa+fb≤ q q∈a+b =
+        proof _ , isProp<' by do
+        (s , t , s∈a , t∈b , q≡s+t) ← ∈→Inhab (+upper a b) q∈a+b
+        return (subst (map-helper a +' map-helper b <'_)
+          (sym (pres+ s t) ∙ (λ i → f-map (q≡s+t (~ i))))
+          (+-Pres<' (map-helper< a s s∈a) (map-helper< b t t∈b)))
 
       fa+fb≤fa+b : map-helper a +' map-helper b ≤' map-helper (a +𝕂 b)
       fa+fb≤fa+b = map-sup (a +𝕂 b) .bound _ (Inhab→∈ (map-prop (a +𝕂 b)) fa+fb≤)
 
       ¬fa+fb<fa+b : ¬ map-helper a +' map-helper b <' map-helper (a +𝕂 b)
       ¬fa+fb<fa+b fa+fb<fa+b =
-        let (s , t , fa<s , fb<t , fa+b≡s+t)
-              = <-+-Decompose' (map-helper a) (map-helper b) _ fa+fb<fa+b
-        in  Prop.rec2 isProp⊥
-            (λ (p , p∈a , fp<s) (q , q∈b , fq<t) →
-              let fp+q<fa+b : f-map (p + q) <' map-helper (a +𝕂 b)
-                  fp+q<fa+b = transport (λ i → pres+ p q (~ i) <' fa+b≡s+t (~ i)) (+-Pres<' fp<s fq<t)
-                  p+q∈a+b : (p + q) ∈ (a +𝕂 b) .upper
-                  p+q∈a+b = Inhab→∈ (+upper a b) ∣ p , q , p∈a , q∈b , refl ∣₁
-              in  <'-asym fp+q<fa+b (map-helper< (a +𝕂 b) _ p+q∈a+b))
-            (>map-helper a s fa<s) (>map-helper b t fb<t)
+        proof _ , isProp⊥ by do
+        let (s , t , fa<s , fb<t , fa+b≡s+t) =
+              <-+-Decompose' (map-helper a) (map-helper b) _ fa+fb<fa+b
+        (p , p∈a , fp<s) ← >map-helper a s fa<s
+        (q , q∈b , fq<t) ← >map-helper b t fb<t
+        let fp+q<fa+b : f-map (p + q) <' map-helper (a +𝕂 b)
+            fp+q<fa+b = transport (λ i → pres+ p q (~ i) <' fa+b≡s+t (~ i)) (+-Pres<' fp<s fq<t)
+            p+q∈a+b : (p + q) ∈ (a +𝕂 b) .upper
+            p+q∈a+b = Inhab→∈ (+upper a b) ∣ p , q , p∈a , q∈b , refl ∣₁
+        return (<'-asym fp+q<fa+b (map-helper< (a +𝕂 b) _ p+q∈a+b))
 
       map-pres+ : map-helper (a +𝕂 b) ≡ map-helper a +' map-helper b
       map-pres+ = case-split (trichotomy' _ _)
@@ -316,34 +309,35 @@ module UniversalProperty ⦃ 🤖 : Oracle ⦄
         b₊ = b , b≥0
 
       fa·fb≤ : (q : K) → q ∈ (a₊ ·𝕂₊ b₊) .fst .upper → map-helper a ·' map-helper b <' f-map q
-      fa·fb≤ q q∈a·b = Prop.rec isProp<'
-        (λ (s , t , s∈a , t∈b , q≡s·t) →
+      fa·fb≤ q q∈a·b =
+        proof _ , isProp<' by do
+        (s , t , s∈a , t∈b , q≡s·t) ← ∈→Inhab (·upper₊ a₊ b₊) q∈a·b
+        return (
           subst (map-helper a ·' map-helper b <'_)
             (sym (pres· s t) ∙ (λ i → f-map (q≡s·t (~ i))))
             (·-PosPres≥0>0' (map-helper-pres≥0 a a≥0) (map-helper-pres≥0 b b≥0)
               (homPres>0 _ (≥𝕂0+q∈upper→q>0 a a≥0 s∈a)) (homPres>0 _ (≥𝕂0+q∈upper→q>0 b b≥0 t∈b))
               (map-helper< a s s∈a) (map-helper< b t t∈b)))
-        (∈→Inhab (·upper₊ a₊ b₊) q∈a·b)
 
       fa·fb≤fa·b : map-helper a ·' map-helper b ≤' map-helper ((a₊ ·𝕂₊ b₊) .fst)
       fa·fb≤fa·b = map-sup ((a₊ ·𝕂₊ b₊) .fst) .bound _ (Inhab→∈ (map-prop ((a₊ ·𝕂₊ b₊) .fst)) fa·fb≤)
 
       ¬fa·fb<fa·b : ¬ map-helper a ·' map-helper b <' map-helper ((a₊ ·𝕂₊ b₊) .fst)
       ¬fa·fb<fa·b fa·fb<fa·b =
-        let (s , t , fa<s , fb<t , fa·b≡s·t)
-              = <-·-Decompose' (map-helper a) (map-helper b) _
-                  (map-helper-pres>0 a a>0) (map-helper-pres>0 b b>0) fa·fb<fa·b
-        in  Prop.rec2 isProp⊥
-            (λ (p , p∈a , fp<s) (q , q∈b , fq<t) →
-              let fp·q<fa·b : f-map (p · q) <' map-helper ((a₊ ·𝕂₊ b₊) .fst)
-                  fp·q<fa·b =
-                    transport (λ i → pres· p q (~ i) <' fa·b≡s·t (~ i))
-                      (·-PosPres>' (homPres>0 _ (≥𝕂0+q∈upper→q>0 a a≥0 p∈a))
-                        (homPres>0 _ (≥𝕂0+q∈upper→q>0 b b≥0 q∈b)) fp<s fq<t)
-                  p·q∈a·b : (p · q) ∈ (a₊ ·𝕂₊ b₊) .fst .upper
-                  p·q∈a·b = Inhab→∈ (·upper₊ a₊ b₊) ∣ p , q , p∈a , q∈b , refl ∣₁
-              in  <'-asym fp·q<fa·b (map-helper<  ((a₊ ·𝕂₊ b₊) .fst) _ p·q∈a·b))
-            (>map-helper a s fa<s) (>map-helper b t fb<t)
+        proof _ , isProp⊥ by do
+        let (s , t , fa<s , fb<t , fa·b≡s·t) =
+              <-·-Decompose' (map-helper a) (map-helper b) _
+              (map-helper-pres>0 a a>0) (map-helper-pres>0 b b>0) fa·fb<fa·b
+        (p , p∈a , fp<s) ← >map-helper a s fa<s
+        (q , q∈b , fq<t) ← >map-helper b t fb<t
+        let fp·q<fa·b : f-map (p · q) <' map-helper ((a₊ ·𝕂₊ b₊) .fst)
+            fp·q<fa·b =
+              transport (λ i → pres· p q (~ i) <' fa·b≡s·t (~ i))
+              (·-PosPres>' (homPres>0 _ (≥𝕂0+q∈upper→q>0 a a≥0 p∈a))
+                (homPres>0 _ (≥𝕂0+q∈upper→q>0 b b≥0 q∈b)) fp<s fq<t)
+            p·q∈a·b : (p · q) ∈ (a₊ ·𝕂₊ b₊) .fst .upper
+            p·q∈a·b = Inhab→∈ (·upper₊ a₊ b₊) ∣ p , q , p∈a , q∈b , refl ∣₁
+        return (<'-asym fp·q<fa·b (map-helper<  ((a₊ ·𝕂₊ b₊) .fst) _ p·q∈a·b))
 
       map-pres·PosPos' : map-helper ((a₊ ·𝕂₊ b₊) .fst) ≡ map-helper a ·' map-helper b
       map-pres·PosPos' = case-split (trichotomy' _ _)

--- a/Classical/Algebra/OrderedField/Morphism.agda
+++ b/Classical/Algebra/OrderedField/Morphism.agda
@@ -14,6 +14,7 @@ open import Cubical.Data.Sigma
 open import Cubical.Data.Empty as Empty
 open import Cubical.Data.Nat using (ℕ ; zero ; suc)
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 open import Cubical.HITs.SetQuotients as SetQuot
 open import Cubical.Relation.Nullary
 open import Cubical.Algebra.Ring
@@ -176,16 +177,16 @@ module OrderedFieldHomStr (f : OrderedFieldHom 𝒦' 𝒦) where
   isLowerUnbounded = (x : K) → ∥ Σ[ r ∈ K' ] f-map r < x ∥₁
 
   isUnbounded→isLowerUnbounded : isUnbounded → isLowerUnbounded
-  isUnbounded→isLowerUnbounded exceed x = Prop.map
-    (λ (r , fr>-x) → -' r ,
+  isUnbounded→isLowerUnbounded exceed x = do
+    (r , fr>-x) ← exceed (- x)
+    return (-' r ,
       transport (λ i → pres- r (~ i) < -Idempotent x i) (-Reverse< fr>-x))
-    (exceed (- x))
 
   isLowerUnbounded→isUnbounded : isLowerUnbounded → isUnbounded
-  isLowerUnbounded→isUnbounded -exceed x = Prop.map
-    (λ (r , fr<-x) → -' r ,
+  isLowerUnbounded→isUnbounded -exceed x = do
+    (r , fr<-x) ← -exceed (- x)
+    return (-' r ,
       transport (λ i → pres- r (~ i) > -Idempotent x i) (-Reverse< fr<-x))
-    (-exceed (- x))
 
 
   isLowerUnboundedΣ : Type _
@@ -203,19 +204,17 @@ module OrderedFieldHomStr (f : OrderedFieldHom 𝒦' 𝒦) where
   isArbitrarilySmall = (x : K) → x > 0r → ∥ Σ[ r ∈ K' ] (0r < f-map r) × (f-map r < x) ∥₁
 
   isUnbounded→isArbitrarilySmall : isUnbounded → isArbitrarilySmall
-  isUnbounded→isArbitrarilySmall exceed x x>0 =
-    Prop.map
-    (λ (r , fr>x⁻¹) →
-      let x⁻¹>0 : inv₊ x>0 > 0r
-          x⁻¹>0 = p>0→p⁻¹>0 x>0
-          r>0 : r >' 0r'
-          r>0 = homRefl>0 _ (<-trans x⁻¹>0 fr>x⁻¹)
-          fr>0 : f-map r > 0r
-          fr>0 = homPres>0 _ r>0
-          fr⁻¹<x⁻¹⁻¹ = inv-Reverse< fr>0 x⁻¹>0 fr>x⁻¹
-      in  _ , homPres>0 _ (p>'0→p⁻¹>'0 r>0) ,
-          transport (λ i → homPresInv r>0 (~ i) < inv₊Idem x>0 i) fr⁻¹<x⁻¹⁻¹)
-    (exceed (inv₊ x>0))
+  isUnbounded→isArbitrarilySmall exceed x x>0 = do
+    (r , fr>x⁻¹) ← exceed (inv₊ x>0)
+    let x⁻¹>0 : inv₊ x>0 > 0r
+        x⁻¹>0 = p>0→p⁻¹>0 x>0
+        r>0 : r >' 0r'
+        r>0 = homRefl>0 _ (<-trans x⁻¹>0 fr>x⁻¹)
+        fr>0 : f-map r > 0r
+        fr>0 = homPres>0 _ r>0
+        fr⁻¹<x⁻¹⁻¹ = inv-Reverse< fr>0 x⁻¹>0 fr>x⁻¹
+    return (_ , homPres>0 _ (p>'0→p⁻¹>'0 r>0) ,
+      transport (λ i → homPresInv r>0 (~ i) < inv₊Idem x>0 i) fr⁻¹<x⁻¹⁻¹)
 
 
   isArbitrarilySmallΣ : Type _

--- a/Classical/Algebra/OrderedField/Properties.agda
+++ b/Classical/Algebra/OrderedField/Properties.agda
@@ -14,6 +14,7 @@ open import Cubical.Data.Empty as Empty
 open import Cubical.Data.Nat using (ℕ ; zero ; suc)
 open import Cubical.Data.NatPlusOne
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 open import Cubical.Relation.Nullary
 open import Cubical.Algebra.CommRing
 open import Cubical.Tactics.CommRingSolver.Reflection
@@ -149,8 +150,9 @@ module OrderedFieldStr (𝒦 : OrderedField ℓ ℓ') where
 
   p>0→p⁻¹>0 : (p>0 : p > 0r) → inv₊ p>0 > 0r
   p>0→p⁻¹>0 {p = p} p>0 = ·-rPosCancel>0 {x = p} {y = inv₊ p>0} p>0 p·p⁻¹>0
-    where p·p⁻¹>0 : p · inv₊ p>0 > 0r
-          p·p⁻¹>0 = subst (_> 0r) (sym (·-rInv₊ p>0)) 1>0
+    where
+    p·p⁻¹>0 : p · inv₊ p>0 > 0r
+    p·p⁻¹>0 = subst (_> 0r) (sym (·-rInv₊ p>0)) 1>0
 
   p>q>0→p·q⁻¹>1 : (q>0 : q > 0r) → p > q → p · inv₊ q>0 > 1r
   p>q>0→p·q⁻¹>1 {q = q} {p = p} q>0 p>q =
@@ -159,17 +161,18 @@ module OrderedFieldStr (𝒦 : OrderedField ℓ ℓ') where
 
   inv-Reverse< : (p>0 : p > 0r)(q>0 : q > 0r) → p > q → inv₊ p>0 < inv₊ q>0
   inv-Reverse< {p = p} {q = q} p>0 q>0 p>q = q⁻¹>p⁻¹
-    where p⁻¹ = inv₊ p>0
-          q⁻¹ = inv₊ q>0
-          p⁻¹·q⁻¹>0 : p⁻¹ · q⁻¹ > 0r
-          p⁻¹·q⁻¹>0 = ·-Pres>0 {x = p⁻¹} {y = q⁻¹} (p>0→p⁻¹>0 {p = p} p>0) (p>0→p⁻¹>0 {p = q} q>0)
-          p·p⁻¹·q⁻¹>q·q⁻¹·p⁻¹ : (p · p⁻¹) · q⁻¹ > (q · q⁻¹) · p⁻¹
-          p·p⁻¹·q⁻¹>q·q⁻¹·p⁻¹ = transport (λ i → helper2 p p⁻¹ q⁻¹ i > helper3 q p⁻¹ q⁻¹ i)
-            (·-rPosPres< {x = p⁻¹ · q⁻¹} {y = q} {z = p} p⁻¹·q⁻¹>0 p>q)
-          1·q⁻¹>1·p⁻¹ : 1r · q⁻¹ > 1r · p⁻¹
-          1·q⁻¹>1·p⁻¹ = transport (λ i → ·-rInv₊ p>0 i · q⁻¹ > ·-rInv₊ q>0 i · p⁻¹) p·p⁻¹·q⁻¹>q·q⁻¹·p⁻¹
-          q⁻¹>p⁻¹ : q⁻¹ > p⁻¹
-          q⁻¹>p⁻¹ = transport (λ i → ·IdL q⁻¹ i > ·IdL p⁻¹ i) 1·q⁻¹>1·p⁻¹
+    where
+    p⁻¹ = inv₊ p>0
+    q⁻¹ = inv₊ q>0
+    p⁻¹·q⁻¹>0 : p⁻¹ · q⁻¹ > 0r
+    p⁻¹·q⁻¹>0 = ·-Pres>0 {x = p⁻¹} {y = q⁻¹} (p>0→p⁻¹>0 {p = p} p>0) (p>0→p⁻¹>0 {p = q} q>0)
+    p·p⁻¹·q⁻¹>q·q⁻¹·p⁻¹ : (p · p⁻¹) · q⁻¹ > (q · q⁻¹) · p⁻¹
+    p·p⁻¹·q⁻¹>q·q⁻¹·p⁻¹ = transport (λ i → helper2 p p⁻¹ q⁻¹ i > helper3 q p⁻¹ q⁻¹ i)
+      (·-rPosPres< {x = p⁻¹ · q⁻¹} {y = q} {z = p} p⁻¹·q⁻¹>0 p>q)
+    1·q⁻¹>1·p⁻¹ : 1r · q⁻¹ > 1r · p⁻¹
+    1·q⁻¹>1·p⁻¹ = transport (λ i → ·-rInv₊ p>0 i · q⁻¹ > ·-rInv₊ q>0 i · p⁻¹) p·p⁻¹·q⁻¹>q·q⁻¹·p⁻¹
+    q⁻¹>p⁻¹ : q⁻¹ > p⁻¹
+    q⁻¹>p⁻¹ = transport (λ i → ·IdL q⁻¹ i > ·IdL p⁻¹ i) 1·q⁻¹>1·p⁻¹
 
   inv₊Idem : (q>0 : q > 0r) → inv₊ (p>0→p⁻¹>0 q>0) ≡ q
   inv₊Idem {q = q} q>0 = sym (·IdL _)
@@ -295,11 +298,11 @@ module _ (𝒦 : OrderedField ℓ ℓ')(archimedes : isArchimedean (𝒦 .fst)) 
       1r/n>0 n = ·-Pres>0 1>0 (1/n>0 n)
 
       ∃P'n : ∥ Σ[ n ∈ ℕ ] P' n ∥₁
-      ∃P'n = Prop.map
-        (λ (ε , ε>0 , pε) →
-          let (1+ n , 1/n<ε) =
-                isArchimedean→isArchimedeanInv ε 1r ε>0 1>0
-          in  n , <-close _ _ (1r/n>0 _) 1/n<ε pε) ∃ε
+      ∃P'n = do
+        (ε , ε>0 , pε) ← ∃ε
+        let (1+ n , 1/n<ε) =
+              isArchimedean→isArchimedeanInv ε 1r ε>0 1>0
+        return (n , <-close _ _ (1r/n>0 _) 1/n<ε pε)
 
     findExplicit : Σ[ ε ∈ K ] (ε > 0r) × P ε
     findExplicit = let (n , p) = find (λ _ → decP _) ∃P'n in 1r / (1+ n) , (1r/n>0 _) , p

--- a/Classical/Analysis/Function/Continuity.agda
+++ b/Classical/Analysis/Function/Continuity.agda
@@ -16,6 +16,7 @@ open import Cubical.Data.Empty as Empty
 open import Cubical.Data.Sum
 open import Cubical.Data.Sigma
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 open import Cubical.Relation.Nullary
 open import Cubical.Algebra.CommRing
 open import Cubical.Tactics.CommRingSolver.Reflection
@@ -269,22 +270,22 @@ module _ ⦃ 🤖 : Oracle ⦄ where
       ∃between = <sup→∃∈ _ f<0-sup x₀-δ<x₀
 
       ¬fx₀>0 : ⊥
-      ¬fx₀>0 = Prop.rec isProp⊥
-        (λ (x , x₀-δ<x , x∈sub) →
-          let x≤x₀ : x ≤ x₀
-              x≤x₀ = f<0-sup .bound _ x∈sub
-              ∣x-x₀∣<δ₀ : abs (x₀ - x) < δ₀
-              ∣x-x₀∣<δ₀ = ≤<-trans (absInBetween δ>0 (inl x₀-δ<x) x≤x₀) (δ-tetrad .snd .snd .snd)
-              x-pair = ∈→Inhab f<0-prop x∈sub
-              instance
-                x∈𝐈 : x ∈ 𝐈
-                x∈𝐈 = x-pair .fst
-              fx<0 : f .fun x < 0
-              fx<0 = x-pair .snd
-              fx>0 : f .fun x > 0
-              fx>0 = δ₀-triple .snd .snd x ∣x-x₀∣<δ₀
-          in  <-asym fx<0 fx>0)
-        ∃between
+      ¬fx₀>0 =
+        proof _ , isProp⊥ by do
+        (x , x₀-δ<x , x∈sub) ← ∃between
+        let x≤x₀ : x ≤ x₀
+            x≤x₀ = f<0-sup .bound _ x∈sub
+            ∣x-x₀∣<δ₀ : abs (x₀ - x) < δ₀
+            ∣x-x₀∣<δ₀ = ≤<-trans (absInBetween δ>0 (inl x₀-δ<x) x≤x₀) (δ-tetrad .snd .snd .snd)
+            x-pair = ∈→Inhab f<0-prop x∈sub
+            instance
+              x∈𝐈 : x ∈ 𝐈
+              x∈𝐈 = x-pair .fst
+            fx<0 : f .fun x < 0
+            fx<0 = x-pair .snd
+            fx>0 : f .fun x > 0
+            fx>0 = δ₀-triple .snd .snd x ∣x-x₀∣<δ₀
+        return (<-asym fx<0 fx>0)
 
     fx₀≡0 : f .fun x₀ ≡ 0
     fx₀≡0 = case-split (trichotomy (f .fun x₀) 0)

--- a/Classical/Analysis/Real/Topology.agda
+++ b/Classical/Analysis/Real/Topology.agda
@@ -18,6 +18,7 @@ open import Cubical.Data.Sum
 open import Cubical.Data.Sigma
 open import Cubical.Data.Empty as Empty
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 open import Cubical.Relation.Nullary
 
 open import Classical.Axioms
@@ -158,15 +159,15 @@ module _ ⦃ 🤖 : Oracle ⦄ where
         cov-sup = getSup ∣ a , Inhab→∈ cov-prop (a∈𝐈 a b , cov-a) ∣₁ ∣ b , b≥x∈sub ∣₁
           where
           cov-a : ∥ Σ[ 𝒰₀ ∈ ℙ (ℙ ℝ) ] 𝒰₀ ⊆ 𝒰 × isFinSub 𝒰₀ × 𝒰₀ covers [ a , a ] ⦃ ∈→Inhab𝐈-L (a∈𝐈 a b) ⦄ ∥₁
-          cov-a = Prop.map
-            (λ (U , a∈U , U∈𝒰) →
+          cov-a = do
+            (U , a∈U , U∈𝒰) ← ∈cover (a∈𝐈 a b) 𝒰cov𝐈
+            return (
               [[ U ]] , A∈S→[A]⊆S U∈𝒰 , isFinSub[x] ,
               (λ {x} x∈[a,a] →
                 let a≡x : a ≡ x
                     a≡x = x∈[a,b] refl x∈[a,a]
                 in  subst (x ∈_) (sym union[A]) (subst (_∈ U) a≡x a∈U)) ,
               A∈S→[A]⊆S (𝒰cov𝐈 .snd U∈𝒰))
-            (∈cover (a∈𝐈 a b) 𝒰cov𝐈)
 
         x₀ = cov-sup .sup
 
@@ -263,26 +264,24 @@ module _ ⦃ 🤖 : Oracle ⦄ where
             x₀∈cov×¬x₀<b' = x₀∈cov , no-way
 
         ∃ℬ : ∥ Σ[ U ∈ ℙ ℝ ] Σ[ r ∈ ℝ ] Σ[ r>0 ∈ r > 0 ] (U ∈ 𝒰) × (ℬ x₀ r ⦃ r>0 ⦄ ⊆ U) ∥₁
-        ∃ℬ = Prop.rec squash₁
-          (λ (U , x₀∈U , U∈𝒰) → Prop.map
-          (λ (r , r>0 , ℬxr⊆U) → U , r , r>0 , U∈𝒰 , (λ p → ℬxr⊆U p))
-          (∈→Inhab𝓂 (𝒰cov𝐈 .snd U∈𝒰) x₀ x₀∈U))
-          (∈cover x₀∈𝐈 𝒰cov𝐈)
+        ∃ℬ = do
+          (U , x₀∈U , U∈𝒰) ← ∈cover x₀∈𝐈 𝒰cov𝐈
+          (r , r>0 , ℬxr⊆U) ← ∈→Inhab𝓂 (𝒰cov𝐈 .snd U∈𝒰) x₀ x₀∈U
+          return (U , r , r>0 , U∈𝒰 , (λ p → ℬxr⊆U p))
 
         isProp×' : isProp ((x₀ ∈ cov-sub) × (¬ x₀ < b))
         isProp×' = isProp× (isProp∈ cov-sub) (isProp¬ _)
 
         x₀∈cov×¬x₀<b : (x₀ ∈ cov-sub) × (¬ x₀ < b)
-        x₀∈cov×¬x₀<b = Prop.rec isProp×'
-          (λ (U , r , r>0 , U∈𝒰 , ℬxr⊆U) → Prop.rec isProp×'
-          (λ (y , x₀-r<y , y∈sub) → Prop.rec isProp×'
-          (λ (𝒰₀ , 𝒰₀⊆𝒰 , fin𝒰₀ , cov) →
-            x₀∈cov×¬x₀<b'
-              U r ⦃ r>0 ⦄ U∈𝒰 ℬxr⊆U
-              y x₀-r<y y∈sub
-              𝒰₀ 𝒰₀⊆𝒰 fin𝒰₀ cov)
-          (∈→Inhab cov-prop y∈sub .snd))
-          (<sup→∃∈ (x₀ - r) cov-sup (-rPos→< r>0))) ∃ℬ
+        x₀∈cov×¬x₀<b =
+          proof _ , isProp×' by do
+          (U , r , r>0 , U∈𝒰 , ℬxr⊆U) ← ∃ℬ
+          (y , x₀-r<y , y∈sub) ← <sup→∃∈ (x₀ - r) cov-sup (-rPos→< r>0)
+          (𝒰₀ , 𝒰₀⊆𝒰 , fin𝒰₀ , cov) ← ∈→Inhab cov-prop y∈sub .snd
+          return (x₀∈cov×¬x₀<b'
+            U r ⦃ r>0 ⦄ U∈𝒰 ℬxr⊆U
+            y x₀-r<y y∈sub
+            𝒰₀ 𝒰₀⊆𝒰 fin𝒰₀ cov)
 
         x₀≡b : x₀ ≡ b
         x₀≡b = ≤+¬<→≡ x₀≤b (x₀∈cov×¬x₀<b .snd)
@@ -316,14 +315,14 @@ module _ ⦃ 🤖 : Oracle ⦄ where
   isBoundedByInterval A = ∥ Σ[ a ∈ ℝ ] Σ[ b ∈ ℝ ] Σ[ a≤b ∈ a ≤ b ] A ⊆ [ a , b ] ⦃ a≤b ⦄ ∥₁
 
   isBoundedSub→isBoundedByInterval : {A : ℙ ℝ} → isBoundedSub A → isBoundedByInterval A
-  isBoundedSub→isBoundedByInterval =
-    Prop.map (λ (a , b , a≤b , h) →
-      a , b , a≤b , λ {x} x∈A → Inhab→∈𝐈 ⦃ a≤b ⦄ (h x x∈A .fst) (h x x∈A .snd))
+  isBoundedSub→isBoundedByInterval x = do
+    (a , b , a≤b , h) ← x
+    return (a , b , a≤b , λ {x} x∈A → Inhab→∈𝐈 ⦃ a≤b ⦄ (h x x∈A .fst) (h x x∈A .snd))
 
   isBoundedByInterval→isBoundedSub : {A : ℙ ℝ} → isBoundedByInterval A → isBoundedSub A
-  isBoundedByInterval→isBoundedSub =
-    Prop.map (λ (a , b , a≤b , A⊆𝐈) →
-      a , b , a≤b , λ x x∈A → ∈→Inhab𝐈-L ⦃ a≤b ⦄ (A⊆𝐈 x∈A) , ∈→Inhab𝐈-R ⦃ a≤b ⦄ (A⊆𝐈 x∈A))
+  isBoundedByInterval→isBoundedSub x = do
+    (a , b , a≤b , A⊆𝐈) ← x
+    return (a , b , a≤b , λ x x∈A → ∈→Inhab𝐈-L ⦃ a≤b ⦄ (A⊆𝐈 x∈A) , ∈→Inhab𝐈-R ⦃ a≤b ⦄ (A⊆𝐈 x∈A))
 
 
   {-
@@ -336,7 +335,6 @@ module _ ⦃ 🤖 : Oracle ⦄ where
 
   isBoundedClosedSub→isCompactSub : {A : ℙ ℝ} → isBoundedSub A → isClosedSub A → isCompactSub A
   isBoundedClosedSub→isCompactSub {A = A} bA cA =
-    Prop.rec isPropIsCompactSub
-    (λ (a , b , a≤b , A⊆𝐈) →
-      isClosedInCompact→isCompact A⊆𝐈 cA ( isCompactInterval a b ⦃ a≤b ⦄))
-    (isBoundedSub→isBoundedByInterval bA)
+    proof _ , isPropIsCompactSub by do
+    (a , b , a≤b , A⊆𝐈) ← isBoundedSub→isBoundedByInterval bA
+    return (isClosedInCompact→isCompact A⊆𝐈 cA ( isCompactInterval a b ⦃ a≤b ⦄))

--- a/Classical/Foundations/Powerset/BigOps.agda
+++ b/Classical/Foundations/Powerset/BigOps.agda
@@ -12,6 +12,7 @@ open import Cubical.Data.Empty as Empty
 open import Cubical.Data.Sum
 open import Cubical.Data.Sigma
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 open import Cubical.Relation.Nullary
 
 open import Classical.Axioms
@@ -78,13 +79,12 @@ module _ ⦃ 🤖 : Oracle ⦄ where
   union∪ {S = S} {T = T} = bi⊆→≡ ∪-S∪T⊆∪S-∪-∪T ∪S-∪-∪T⊆∪-S∪T
     where
     ∪-S∪T⊆∪S-∪-∪T : union (S ∪ T) ⊆ union S ∪ union T
-    ∪-S∪T⊆∪S-∪-∪T x∈∪-S∪T = ∈A+∈B→∈A∪B (union S) (union T)
-      (Prop.map
-      (λ (A , x∈A , A∈S∪T) →
+    ∪-S∪T⊆∪S-∪-∪T x∈∪-S∪T = ∈A+∈B→∈A∪B (union S) (union T) do
+      (A , x∈A , A∈S∪T) ← ∈union→∃ x∈∪-S∪T
+      return (
         case ∈A∪B→∈A+∈B S T A∈S∪T of λ
         { (inl A∈S) → inl (∃→∈union ∣ A , x∈A , A∈S ∣₁)
         ; (inr A∈T) → inr (∃→∈union ∣ A , x∈A , A∈T ∣₁) })
-      (∈union→∃ x∈∪-S∪T))
 
     ∪S-∪-∪T⊆∪-S∪T : union S ∪ union T ⊆ union (S ∪ T)
     ∪S-∪-∪T⊆∪-S∪T x∈∪S-∪-∪T = ∃→∈union
@@ -105,10 +105,10 @@ module _ ⦃ 🤖 : Oracle ⦄ where
     where
     ∪[A]⊆A : union [ A ] ⊆ A
     ∪[A]⊆A {x = x} x∈∪[A] =
-      Prop.rec (isProp∈ A)
-      (λ (B , x∈B , B∈[A]) →
-        Prop.rec (isProp∈ A) (λ A≡B → subst (x ∈_) (sym A≡B) x∈B)
-      (y∈[x]→∥x≡y∥ B∈[A])) (∈union→∃ x∈∪[A])
+      proof _ , isProp∈ A by do
+      (B , x∈B , B∈[A]) ← ∈union→∃ x∈∪[A]
+      A≡B ← y∈[x]→∥x≡y∥ B∈[A]
+      return (subst (x ∈_) (sym A≡B) x∈B)
 
     A⊆∪[A] : A ⊆ union [ A ]
     A⊆∪[A] x∈A = ∃→∈union ∣ A , x∈A , x∈[x] ∣₁

--- a/Classical/Topology/Hausdorff.agda
+++ b/Classical/Topology/Hausdorff.agda
@@ -15,6 +15,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
 open import Cubical.Data.Sigma
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 open import Cubical.Relation.Nullary
 
 open import Classical.Axioms
@@ -75,10 +76,10 @@ module _ ⦃ 🤖 : Oracle ⦄ where
         -- A shuffle of propositions
         K⊆𝕌 : K ⊆ 𝕌
         K⊆𝕌 x∈K =
-          Prop.rec (isProp∈ 𝕌)
-          (λ (U , V , U∈ℕx , V∈ℕx₀ , U∩V≡∅) →
-             ∃→∈union ∣ U , N∈ℕbhx→x∈N U∈ℕx , Inhab→∈ P ∣ _ , x∈K , U∈ℕx , ∣ V , V∈ℕx₀ , U∩V≡∅ ∣₁ ∣₁ ∣₁)
-          (separate (∈∉→≢ x∈K x₀∉K))
+          proof _ , isProp∈ 𝕌 by do
+          (U , V , U∈ℕx , V∈ℕx₀ , U∩V≡∅) ← separate (∈∉→≢ x∈K x₀∉K)
+          return
+            (∃→∈union ∣ U , N∈ℕbhx→x∈N U∈ℕx , Inhab→∈ P ∣ _ , x∈K , U∈ℕx , ∣ V , V∈ℕx₀ , U∩V≡∅ ∣₁ ∣₁ ∣₁)
 
         𝒰-covers-K : 𝒰 covers K
         𝒰-covers-K = K⊆𝕌 , 𝒰⊆Open
@@ -88,17 +89,16 @@ module _ ⦃ 🤖 : Oracle ⦄ where
 
         -- Another shuffle of propositions
         ∃𝒰₀ : ∥ Σ[ 𝒰₀ ∈ ℙ ℙ X ] 𝒰₀ ⊆ Open × isFinSub 𝒰₀ × 𝒰₀ covers K × ((U : ℙ X) → U ∈ 𝒰₀ → Sep x₀ U) ∥₁
-        ∃𝒰₀ =
-          Prop.map
-          (λ (𝒰₀ , 𝒰₀⊆𝒰 , fin𝒰₀ , 𝒰₀covK) →
-              𝒰₀ , ⊆-trans {C = Open} 𝒰₀⊆𝒰 𝒰⊆Open , fin𝒰₀ , 𝒰₀covK ,
-              λ U U∈𝒰₀ → Prop.rec squash₁ (λ (_ , _ , _ , sep) → sep) (∈→Inhab P (∈⊆-trans {B = 𝒰} U∈𝒰₀ 𝒰₀⊆𝒰)))
-          (takefin 𝒰-covers-K)
+        ∃𝒰₀ = do
+          (𝒰₀ , 𝒰₀⊆𝒰 , fin𝒰₀ , 𝒰₀covK) ← takefin 𝒰-covers-K
+          return (
+            𝒰₀ , ⊆-trans {C = Open} 𝒰₀⊆𝒰 𝒰⊆Open , fin𝒰₀ , 𝒰₀covK ,
+            λ U U∈𝒰₀ → Prop.rec squash₁ (λ (_ , _ , _ , sep) → sep) (∈→Inhab P (∈⊆-trans {B = 𝒰} U∈𝒰₀ 𝒰₀⊆𝒰)))
 
         sepOpen : SepOpen x₀ K
-        sepOpen = Prop.rec squash₁
-          (λ (_ , 𝒰₀⊆Open , fin⊆𝒰₀ , 𝒰₀covK , sep)
-              →  SepOpen⊆ (union∈Open 𝒰₀⊆Open) (𝒰₀covK .fst) (unionSep _ _ 𝒰₀⊆Open sep fin⊆𝒰₀)) ∃𝒰₀
+        sepOpen = do
+          (_ , 𝒰₀⊆Open , fin⊆𝒰₀ , 𝒰₀covK , sep) ← ∃𝒰₀
+          SepOpen⊆ (union∈Open 𝒰₀⊆Open) (𝒰₀covK .fst) (unionSep _ _ 𝒰₀⊆Open sep fin⊆𝒰₀)
 
 
       -- Compact subset of Hausdorff space is closed.

--- a/Classical/Topology/Metric/Base.agda
+++ b/Classical/Topology/Metric/Base.agda
@@ -18,6 +18,7 @@ open import Cubical.Data.Sum
 open import Cubical.Data.Empty as Empty
 open import Cubical.Data.Sigma
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 open import Cubical.Relation.Nullary
 
 open import Classical.Axioms
@@ -165,22 +166,20 @@ module _ ⦃ 🤖 : Oracle ⦄ where
     Metric→Topology .has-∅ = Inhab→∈ 𝓂-prop (λ x x∈∅ → Empty.rec (¬x∈∅ x x∈∅))
     Metric→Topology .has-total = Inhab→∈ 𝓂-prop (λ x _ → ∣ 1 , 1>0 , A⊆total {A = ℬ x 1 ⦃ 1>0 ⦄} ∣₁)
     Metric→Topology .∩-close {A = A} {B = B} A∈Open B∈Open =
-      Inhab→∈ 𝓂-prop (λ x x∈A∩B → Prop.map2
-      (λ (r₀ , r₀>0 , ℬxr₀⊆A) (r₁ , r₁>0 , ℬxr₁⊆B) →
-        let (r , r>0 , r<r₀ , r<r₁) = min2 r₀>0 r₁>0 in
+      Inhab→∈ 𝓂-prop (λ x x∈A∩B → do
+      (r₀ , r₀>0 , ℬxr₀⊆A) ← ∈→Inhab 𝓂-prop A∈Open x (left∈-∩  A B x∈A∩B)
+      (r₁ , r₁>0 , ℬxr₁⊆B) ← ∈→Inhab 𝓂-prop B∈Open x (right∈-∩ A B x∈A∩B)
+      let (r , r>0 , r<r₀ , r<r₁) = min2 r₀>0 r₁>0
+      return (
         r , r>0 , ⊆→⊆∩ A B
         (⊆-trans {A = ℬ x r ⦃ r>0 ⦄} (ℬ⊆ ⦃ r>0 ⦄ ⦃ r₀>0 ⦄ r<r₀) ℬxr₀⊆A)
-        (⊆-trans {A = ℬ x r ⦃ r>0 ⦄} (ℬ⊆ ⦃ r>0 ⦄ ⦃ r₁>0 ⦄ r<r₁) ℬxr₁⊆B))
-      (∈→Inhab 𝓂-prop A∈Open x (left∈-∩  A B x∈A∩B))
-      (∈→Inhab 𝓂-prop B∈Open x (right∈-∩ A B x∈A∩B)))
+        (⊆-trans {A = ℬ x r ⦃ r>0 ⦄} (ℬ⊆ ⦃ r>0 ⦄ ⦃ r₁>0 ⦄ r<r₁) ℬxr₁⊆B)))
+
     Metric→Topology .∪-close {S = S} S⊆Open =
-      Inhab→∈ 𝓂-prop (λ x x∈∪S →
-      Prop.rec squash₁
-      (λ (A , x∈A , A∈S) → Prop.map
-        (λ (r , r>0 , ℬxr⊆A) →
-          r , r>0 , (λ p → ⊆union ℬxr⊆A A∈S p))
-        (∈→Inhab 𝓂-prop (S⊆Open A∈S) x x∈A))
-      (∈union→∃ x∈∪S))
+      Inhab→∈ 𝓂-prop (λ x x∈∪S → do
+      (A , x∈A , A∈S) ← ∈union→∃ x∈∪S
+      (r , r>0 , ℬxr⊆A) ← ∈→Inhab 𝓂-prop (S⊆Open A∈S) x x∈A
+      return (r , r>0 , (λ p → ⊆union ℬxr⊆A A∈S p)))
 
 
     private

--- a/Classical/Topology/Metric/Sequence.agda
+++ b/Classical/Topology/Metric/Sequence.agda
@@ -22,6 +22,7 @@ open import Cubical.Data.Nat.Order using ()
           ; isProp≤  to isProp≤ℕ)
 open import Cubical.Data.Sigma
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 
 open import Classical.Axioms
 open import Classical.Foundations.Powerset
@@ -46,7 +47,7 @@ module _ ⦃ 🤖 : Oracle ⦄
 
   {-
 
-    Convergence and Limit of Real Number Sequence
+    Convergence and Limit of Sequence in Metric Spaces
 
   -}
 
@@ -93,13 +94,13 @@ module _ ⦃ 🤖 : Oracle ⦄
       ε/2>0 = middle>l ε>0
 
       ∣x-y∣<ε : dist (p .lim) (q .lim) < ε
-      ∣x-y∣<ε = Prop.rec2 isProp<
-        (λ (n₀ , abs<₀) (n₁ , abs<₁) →
-          let n = sucmax n₀ n₁ in
-          ≤<-trans (dist-Δ _ _ _) (transport
-            (λ i → dist (p .lim) (seq n) + dist-symm (q .lim) (seq n) i < x/2+x/2≡x ε i)
-            (+-Pres< (abs<₀ _ sucmax>left) (abs<₁ _ sucmax>right))))
-        (p .conv ε/2 ε/2>0) (q .conv ε/2 ε/2>0)
+      ∣x-y∣<ε = proof (_ , isProp<) by do
+        (n₀ , abs<₀) ← p .conv ε/2 ε/2>0
+        (n₁ , abs<₁) ← q .conv ε/2 ε/2>0
+        let n = sucmax n₀ n₁
+        return (≤<-trans (dist-Δ _ _ _) (transport
+          (λ i → dist (p .lim) (seq n) + dist-symm (q .lim) (seq n) i < x/2+x/2≡x ε i)
+          (+-Pres< (abs<₀ _ sucmax>left) (abs<₁ _ sucmax>right))))
 
 
   {-

--- a/Classical/Topology/Neighbourhood.agda
+++ b/Classical/Topology/Neighbourhood.agda
@@ -15,6 +15,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
 open import Cubical.Data.Sigma
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 
 open import Classical.Axioms
 open import Classical.Foundations.Powerset
@@ -120,8 +121,9 @@ module _ ⦃ 🤖 : Oracle ⦄ where
       𝕌⊆U = union⊆ N∈𝒰→N⊆U
 
       U⊆𝕌 : U ⊆ 𝕌
-      U⊆𝕌 x∈U = ∃→∈union
-        (Prop.map (λ (N , N∈ℕx , N⊆U) → N , N∈ℕbhx→x∈N N∈ℕx , Inhab→∈ P ∣ _ , N∈ℕx , N⊆U ∣₁) (p _ x∈U))
+      U⊆𝕌 x∈U = ∃→∈union do
+        (N , N∈ℕx , N⊆U) ← p _ x∈U
+        return (N , N∈ℕbhx→x∈N N∈ℕx , Inhab→∈ P ∣ _ , N∈ℕx , N⊆U ∣₁)
 
       𝕌≡U : 𝕌 ≡ U
       𝕌≡U = bi⊆→≡ 𝕌⊆U U⊆𝕌

--- a/Classical/Topology/Properties.agda
+++ b/Classical/Topology/Properties.agda
@@ -15,6 +15,7 @@ open import Cubical.Data.Empty as Empty
 open import Cubical.Data.Sum
 open import Cubical.Data.Sigma
 open import Cubical.HITs.PropositionalTruncation as Prop
+open import Cubical.HITs.PropositionalTruncation.Monad
 
 open import Classical.Axioms
 
@@ -127,9 +128,9 @@ module _ ⦃ 🤖 : Oracle ⦄ where
         case-split (inr U∈[∁A]) = Empty.rec (∉→¬∈ {A = A} (∈∁→∉ {A = A} x∈∁A) x∈A)
           where
           x∈∁A : x ∈ ∁ A
-          x∈∁A = Prop.rec (isProp∈ (∁ A))
-            (λ ∁A≡U → subst (x ∈_) (sym ∁A≡U) x∈U)
-            (y∈[x]→∥x≡y∥ U∈[∁A])
+          x∈∁A = proof _ , isProp∈ (∁ A) by do
+            ∁A≡U ← y∈[x]→∥x≡y∥ U∈[∁A]
+            return (subst (x ∈_) (sym ∁A≡U) x∈U)
 
       module _ (𝒰' : ℙ ℙ X)(𝒰'⊆𝒰+∁A : 𝒰' ⊆ 𝒰+∁A)(fin𝒰' : isFinSub 𝒰')(𝒰'covK : 𝒰' covers K) where
 
@@ -139,15 +140,16 @@ module _ ⦃ 🤖 : Oracle ⦄ where
         𝒰₀ = specify cov-prop
 
         𝒰₀⊆𝒰' : 𝒰₀ ⊆ 𝒰'
-        𝒰₀⊆𝒰' U∈𝒰₀ = Prop.rec (isProp∈ 𝒰')
-          (λ (x , x∈A , x∈U , U∈𝒰') → U∈𝒰')
-          (∈→Inhab cov-prop U∈𝒰₀)
+        𝒰₀⊆𝒰' U∈𝒰₀ =
+          proof _ , isProp∈ 𝒰' by do
+          (x , x∈A , x∈U , U∈𝒰') ← ∈→Inhab cov-prop U∈𝒰₀
+          return U∈𝒰'
 
         𝒰₀⊆𝒰 : 𝒰₀ ⊆ 𝒰
-        𝒰₀⊆𝒰 U∈𝒰₀ = Prop.rec (isProp∈ 𝒰)
-          (λ (x , x∈A , x∈U , U∈𝒰') →
-            a∈U+U∈𝒰+∁A→U∈𝒰 x∈A x∈U (𝒰'⊆𝒰+∁A U∈𝒰'))
-          (∈→Inhab cov-prop U∈𝒰₀)
+        𝒰₀⊆𝒰 U∈𝒰₀ =
+          proof _ , isProp∈ 𝒰 by do
+          (x , x∈A , x∈U , U∈𝒰') ← ∈→Inhab cov-prop U∈𝒰₀
+          return (a∈U+U∈𝒰+∁A→U∈𝒰 x∈A x∈U (𝒰'⊆𝒰+∁A U∈𝒰'))
 
         fin𝒰₀ : isFinSub 𝒰₀
         fin𝒰₀ = isFinSub⊆ 𝒰₀⊆𝒰' fin𝒰'
@@ -156,17 +158,16 @@ module _ ⦃ 🤖 : Oracle ⦄ where
         𝒰₀covA .fst {x = x} x∈A = ∃→∈union ∃U
           where
           ∃U : ∥ Σ[ U ∈ ℙ X ] (x ∈ U) × (U ∈ 𝒰₀) ∥₁
-          ∃U = Prop.map
-            (λ (U , x∈U , U∈𝒰') →
-              U , x∈U , Inhab→∈ cov-prop ∣ x , x∈A , x∈U , U∈𝒰' ∣₁)
-            (∈union→∃ (𝒰'covK .fst (A⊆K x∈A)))
+          ∃U = do
+            (U , x∈U , U∈𝒰') ← ∈union→∃ (𝒰'covK .fst (A⊆K x∈A))
+            return (U , x∈U , Inhab→∈ cov-prop ∣ x , x∈A , x∈U , U∈𝒰' ∣₁)
+
         𝒰₀covA .snd U∈𝒰₀ = 𝒰covA .snd (𝒰₀⊆𝒰 U∈𝒰₀)
 
         Σ𝒰₀ : Σ[ 𝒰₀ ∈ ℙ ℙ X ] 𝒰₀ ⊆ 𝒰 × isFinSub 𝒰₀ × 𝒰₀ covers A
         Σ𝒰₀ = 𝒰₀ , 𝒰₀⊆𝒰 , fin𝒰₀ , 𝒰₀covA
 
       ∃𝒰₀ : ∥ Σ[ 𝒰₀ ∈ ℙ ℙ X ] 𝒰₀ ⊆ 𝒰 × isFinSub 𝒰₀ × 𝒰₀ covers A ∥₁
-      ∃𝒰₀ = Prop.map
-        (λ (𝒰' , 𝒰'⊆𝒰+∁A , fin𝒰' , 𝒰'covK) →
-          Σ𝒰₀ 𝒰' 𝒰'⊆𝒰+∁A fin𝒰' 𝒰'covK)
-        (takefinK 𝒰+∁A-covK)
+      ∃𝒰₀ = do
+        (𝒰' , 𝒰'⊆𝒰+∁A , fin𝒰' , 𝒰'covK) ← takefinK 𝒰+∁A-covK
+        return (Σ𝒰₀ 𝒰' 𝒰'⊆𝒰+∁A fin𝒰' 𝒰'covK)


### PR DESCRIPTION
It seems do-notation can somewhat simplify the weird nesting of recursors and other stuffs when it comes to propositional truncations. So I decide to use it throughout the library.